### PR TITLE
changed border top to decrease divider thickness

### DIFF
--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
# Expected behavior
The separator line in the project cards should match the design.
![image](https://github.com/profydev/prolog-app-jaclynmariefrench/assets/77642588/8a788b6d-b68a-440d-a0d2-707978575509)

#Past behavior
The separator line looks very thick.

#Test

1. Check figma design
2. Compare figma design vs. live site [figma](https://www.figma.com/file/9GdsCOWwLidGW0h7WMMxBo/React-Job-Simulator---Pixel-Perfect-Design-Exercise?type=design&node-id=156-21830&mode=design&t=vTSKBHzSoPAiOQ7V-0)
3. Verify that project separator line matches the figma design

