### PR TITLE
change pagination-color to -500

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-500;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
### Expected behavior
The text color of page info at the bottom of the issue list should match the design

### Current behavior
The page info has a wrong (lighter) color than in the design. The contrast is really low this way which is bad for accessibility. See the designs for the correct color.
![image](https://github.com/profydev/prolog-app-jaclynmariefrench/assets/77642588/8fc73c68-3a7f-4f49-8131-64435d1ee725)

### Test

- [ ] Check [figma](https://www.figma.com/file/9GdsCOWwLidGW0h7WMMxBo/React-Job-Simulator---Pixel-Perfect-Design-Exercise?type=design&node-id=156-21830&mode=design&t=vTSKBHzSoPAiOQ7V-0) design for color, see above image for reference
- [ ] Verify that served site has the correct color based on figma design