### PR TITLE
added arrowFlipped class and added conditional to MenuItemButton

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -139,3 +139,7 @@
     display: flex;
   }
 }
+
+.arrowFlipped {
+  transform: scale(-1);
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.arrowFlipped,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
### Expected behavior
When the sidebar navigation is collapsed the arrow of the “Collapse” button should point to the right.

### Past behavior
The arrow always points to the left regardless of the navigation state.
![image](https://github.com/profydev/prolog-app-jaclynmariefrench/assets/77642588/8e002c2b-5ad4-441f-a2ac-d5b65784a2ab)

### Testing

- [ ] Open ProLog in local environment
- [ ] Confirm that when collapse button in the sidenav is clicked the arrow is facing the right when collapsed