### PR TITLE
added new state to watch window width and added ternary logic to make…

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Routes } from "@config/routes";
 import classNames from "classnames";
 import { NavigationContext } from "./navigation-context";
@@ -21,6 +21,30 @@ export function SidebarNavigation() {
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
 
+  //State for if it's mobile view or not and accounts for the server side rendering delay
+  const [isMobileView, setIsMobileView] = useState(
+    typeof window !== "undefined" ? window.innerWidth <= 1023 : false,
+  );
+
+  useEffect(() => {
+    const handleWindowResize = () => {
+      setIsMobileView(window.innerWidth <= 1023);
+    };
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("resize", handleWindowResize);
+
+      //Cleans event listener
+      return () => {
+        window.removeEventListener("resize", handleWindowResize);
+      };
+    }
+  }, []);
+
+  console.log("isMobileMenuOpen:", isMobileMenuOpen);
+  console.log("isSidebarCollapsed:", isSidebarCollapsed);
+  console.log("isMobileView:", isMobileView);
+
   return (
     <div
       className={classNames(
@@ -38,9 +62,11 @@ export function SidebarNavigation() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={
-              isSidebarCollapsed
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
+              isMobileView
+                ? "/icons/logo-large.svg"
+                : isSidebarCollapsed
+                  ? "/icons/logo-small.svg"
+                  : "/icons/logo-large.svg"
             }
             alt="logo"
             className={styles.logo}


### PR DESCRIPTION
… sure mobile view has the large logo

### Expected behavior
On mobile devices, the header should always show the large logo.

### Past behavior
When a user switches device orientation in a way that results in a change from desktop to mobile mode the small logo is shown instead of the large one.
![image](https://github.com/profydev/prolog-app-jaclynmariefrench/assets/77642588/0251cb2d-eeb3-49bc-9d7c-7e149e457e10)

### Steps to reproduce and verfiy that the logo is set to large-logo while in mobile view
Open the app on a tablet (e.g. iPad in the Chrome Dev Tools)
Turn on landscape
Collapse the sidebar navigation
Rotate the screen to portrait mode
Now the logo in the upper left corner is too big (compare to the designs)
