### PR TITLE
added cypress test for story 5

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -39,6 +39,22 @@ describe("Sidebar Navigation", () => {
         );
     });
 
+    it("correct logo is shown in collapse and when switched to landscape", () => {
+      //collapse the menu
+      cy.get("nav").contains("Collapse").click();
+
+      //check that small logo is present
+      cy.get('img[src="/icons/logo-small.svg"]').should("be.visible");
+      cy.get('img[src="/icons/logo-large.svg"]').should("not.exist");
+
+      //flip viewport to tall
+      cy.viewport(900, 1025);
+
+      //check that large logo is present
+      cy.get('img[src="/icons/logo-small.svg"]').should("not.exist");
+      cy.get('img[src="/icons/logo-large.svg"]').should("be.visible");
+    });
+
     it("is collapsible", () => {
       // collapse navigation
       cy.get("nav").contains("Collapse").click();


### PR DESCRIPTION
Added cypress story to validate that correct logo is shown when:

1. Menu is collapsed = small logo
2. View is mobile or tall = large logo