### PR TITLE
Fix issue list number of events and users

### DIFF
--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -12,4 +12,5 @@ export type Issue = {
   stack: string;
   level: IssueLevel;
   numEvents: number;
+  numUsers: number;
 };

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -45,6 +45,7 @@ describe("Issue List", () => {
           cy.wrap($el).contains(issue.name);
           cy.wrap($el).contains(issue.message);
           cy.wrap($el).contains(issue.numEvents);
+          cy.wrap($el).contains(issue.numUsers);
           cy.wrap($el).contains(firstLineOfStackTrace);
         });
     });

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -17,7 +17,7 @@ const levelColors = {
 };
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
-  const { name, message, stack, level, numEvents } = issue;
+  const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
 
   return (
@@ -43,7 +43,7 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
         </Badge>
       </td>
       <td className={styles.cell}>{numEvents}</td>
-      <td className={styles.cell}>{numEvents}</td>
+      <td className={styles.cell}>{numUsers}</td>
     </tr>
   );
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -41,10 +41,6 @@ export function SidebarNavigation() {
     }
   }, []);
 
-  console.log("isMobileMenuOpen:", isMobileMenuOpen);
-  console.log("isSidebarCollapsed:", isSidebarCollapsed);
-  console.log("isMobileView:", isMobileView);
-
   return (
     <div
       className={classNames(


### PR DESCRIPTION
### Expected behavior
The columns “Events” and “Users” should show the respective numbers from the API data.

### Past behavior
The columns “Events” and “Users” always show the same number. Likely one of them shows the wrong data.
![image](https://github.com/profydev/prolog-app-jaclynmariefrench/assets/77642588/07cd1b1a-0a95-4639-906b-29c1894d595d)

### Test
1. The numbers in the “Events” and “Users” columns match the API data
2. Check that Cypress test is looking for both the correct events and user data