### PR TITLE
Project list incorrect status

### DIFF
--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -20,7 +20,7 @@ describe("Project List", () => {
       cy.viewport(1025, 900);
     });
 
-    it("renders the projects", () => {
+    it("renders the projects and has correct statues", () => {
       const languageNames = ["React", "Node.js", "Python"];
 
       // get all project cards
@@ -28,11 +28,37 @@ describe("Project List", () => {
         .find("li")
         .each(($el, index) => {
           // check that project data is rendered
+          let expectedColor;
+          let expectedText;
+          let badgeColor;
+
+          switch (mockProjects[index].status) {
+            case "error":
+              expectedColor = "rgb(254, 243, 242)";
+              expectedText = "critical";
+              badgeColor = "error";
+              break;
+            case "info":
+              expectedColor = "rgb(236, 253, 243)";
+              expectedText = "stable";
+              badgeColor = "success";
+              break;
+            case "warning":
+              expectedColor = "rgb(255, 250, 235)";
+              expectedText = "warning";
+              badgeColor = "warning";
+              break;
+          }
+
           cy.wrap($el).contains(mockProjects[index].name);
           cy.wrap($el).contains(languageNames[index]);
           cy.wrap($el).contains(mockProjects[index].numIssues);
           cy.wrap($el).contains(mockProjects[index].numEvents24h);
-          cy.wrap($el).contains(capitalize(mockProjects[index].status));
+          cy.wrap($el)
+            .find(`[data-testid="badge-${badgeColor}"]`)
+            .should("exist")
+            .and("have.css", "background-color", expectedColor)
+            .and("contain", capitalize(expectedText));
           cy.wrap($el)
             .find("a")
             .should("have.attr", "href", "/dashboard/issues");

--- a/features/projects/api/use-get-projects.tsx
+++ b/features/projects/api/use-get-projects.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getProjects } from "@api/projects";
 import { ProjectStatus, type Project } from "@api/projects.types";
 
+// Converts project status data from 'info' to 'stable' and 'error' to 'critical'
 function transformStatus(status: string): ProjectStatus {
   switch (status) {
     case "info":

--- a/features/projects/api/use-get-projects.tsx
+++ b/features/projects/api/use-get-projects.tsx
@@ -1,7 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
 import { getProjects } from "@api/projects";
-import type { Project } from "@api/projects.types";
+import { ProjectStatus, type Project } from "@api/projects.types";
+
+function transformStatus(status: string): ProjectStatus {
+  switch (status) {
+    case "info":
+      return ProjectStatus.stable;
+    case "error":
+      return ProjectStatus.critical;
+    default:
+      return status as ProjectStatus;
+  }
+}
 
 export function useGetProjects() {
-  return useQuery<Project[], Error>(["projects"], getProjects);
+  return useQuery<Project[], Error>(["projects"], getProjects, {
+    select: (data) =>
+      data.map((project) => ({
+        ...project,
+        status: transformStatus(project.status),
+      })),
+  });
 }

--- a/features/ui/badge/badge.tsx
+++ b/features/ui/badge/badge.tsx
@@ -28,7 +28,10 @@ export function Badge({
   color = BadgeColor.primary,
 }: BadgeProps) {
   return (
-    <div className={classNames(styles.container, styles[size], styles[color])}>
+    <div
+      className={classNames(styles.container, styles[size], styles[color])}
+      data-testid={`badge-${color}`}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
### Expected behavior
The color and text of the status badge should change according to the status of the project.

The colors should be red, yellow, or green
The text should show “Critical”, “Warning”, or “Stable”

![image](https://github.com/profydev/prolog-app-jaclynmariefrench/assets/77642588/030fba90-b66a-458a-8e46-3f3d4617f4ea)


### Past behavior
The colors for status “Error” and “Info” aren’t shown according to the design.
The text writes “Error” instead of “Critical” and “Info” instead of “Stable”

![image](https://github.com/profydev/prolog-app-jaclynmariefrench/assets/77642588/daf02505-fc28-4a95-a661-b15a868e9dd0)


### Steps to reproduce
Visit the projects page at [localhost:3000/dashboard](http://localhost:3000/dashboard) or https://prolog.profy.dev/dashboard

### Test

- [ ] The color of the status badge matches the project status

- [ ] The text writes “Critical” for the error status and “Stable” for the info status

- [ ] Check project-list cypress test for 'renders the projects and has correct statues' step and that it passes