### PR TITLE
Projects error screen

### DIFF
--- a/features/projects/components/project-error/index.ts
+++ b/features/projects/components/project-error/index.ts
@@ -1,1 +1,2 @@
 export { ProjectError } from "./project-error";
+export type { ProjectErrorProps } from "./project-error";

--- a/features/projects/components/project-error/index.ts
+++ b/features/projects/components/project-error/index.ts
@@ -1,0 +1,1 @@
+export { ProjectError } from "./project-error";

--- a/features/projects/components/project-error/project-error.module.scss
+++ b/features/projects/components/project-error/project-error.module.scss
@@ -1,17 +1,23 @@
-@import "styles/color";
-@import "styles/font";
+@use "@styles/color";
+@use "@styles/font";
+@use "@styles/breakpoint";
 
 .error-container {
-  background-color: $error-25;
-  color: $error-700;
+  background-color: color.$error-25;
+  color: color.$error-700;
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  border: $error-300 solid 1px;
-  border-radius: 8px;
-  font: $text-sm-medium;
-  max-width: 1080px;
-  width: 100%;
-  padding: 0 15px;
+  grid-template-columns: minmax(40px, 2fr) minmax(20px, 1fr);
+  border: color.$error-300 solid 1px;
+  border-radius: 0.5rem;
+  font: font.$text-sm-medium;
+  width: 94vw;
+  padding: 0 1rem;
+  box-sizing: border-box;
+
+  @media (min-width: breakpoint.$desktop) {
+    grid-template-columns: 1fr 1fr;
+    width: 95vw;
+  }
 }
 
 .left-banner,
@@ -19,19 +25,20 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 12px;
+  gap: 0.75rem;
   letter-spacing: 0.5px;
+  word-wrap: break-word;
 }
 
 .right-banner {
   justify-self: end;
-  color: $error-700;
+  color: color.$error-700;
 }
 
 .alert-circle {
-  color: $error-600;
+  color: color.$error-600;
 }
 
 .error-arrow {
-  color: $error-700;
+  color: color.$error-700;
 }

--- a/features/projects/components/project-error/project-error.module.scss
+++ b/features/projects/components/project-error/project-error.module.scss
@@ -1,0 +1,37 @@
+@import "styles/color";
+@import "styles/font";
+
+.error-container {
+  background-color: $error-25;
+  color: $error-700;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border: $error-300 solid 1px;
+  border-radius: 8px;
+  font: $text-sm-medium;
+  max-width: 1080px;
+  width: 100%;
+  padding: 0 15px;
+}
+
+.left-banner,
+.right-banner {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+  letter-spacing: 0.5px;
+}
+
+.right-banner {
+  justify-self: end;
+  color: $error-700;
+}
+
+.alert-circle {
+  color: $error-600;
+}
+
+.error-arrow {
+  color: $error-700;
+}

--- a/features/projects/components/project-error/project-error.stories.tsx
+++ b/features/projects/components/project-error/project-error.stories.tsx
@@ -11,9 +11,5 @@ export default {
   },
 } as Meta<typeof ProjectError>;
 
-const Template: StoryFn<typeof ProjectError> = () => (
-  <div style={{ width: 1440 }}>
-    <ProjectError />
-  </div>
-);
+const Template: StoryFn<typeof ProjectError> = () => <ProjectError />;
 export const Default = Template.bind({});

--- a/features/projects/components/project-error/project-error.stories.tsx
+++ b/features/projects/components/project-error/project-error.stories.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Meta, StoryFn } from "@storybook/react";
+import { ProjectError } from "./project-error";
+
+export default {
+  title: "project/ProjectError",
+  component: ProjectError,
+  parameters: {
+    // More on Story layout: https://storybook.js.org/docs/react/configure/story-layout
+    layout: "fullscreen",
+  },
+} as Meta<typeof ProjectError>;
+
+const Template: StoryFn<typeof ProjectError> = () => (
+  <div style={{ width: 1440 }}>
+    <ProjectError />
+  </div>
+);
+export const Default = Template.bind({});

--- a/features/projects/components/project-error/project-error.stories.tsx
+++ b/features/projects/components/project-error/project-error.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Meta, StoryFn } from "@storybook/react";
-import { ProjectError } from "./project-error";
+import { ProjectError, ProjectErrorProps } from "./project-error";
 
 export default {
   title: "project/ProjectError",
@@ -11,5 +11,9 @@ export default {
   },
 } as Meta<typeof ProjectError>;
 
-const Template: StoryFn<typeof ProjectError> = () => <ProjectError />;
-export const Default = Template.bind({});
+const Template: StoryFn<ProjectErrorProps> = (args) => (
+  <ProjectError {...args} />
+);
+export const Default = Template.bind({
+  onRetry: () => alert("Retry button clicked"),
+});

--- a/features/projects/components/project-error/project-error.tsx
+++ b/features/projects/components/project-error/project-error.tsx
@@ -1,0 +1,31 @@
+import styles from "./project-error.module.scss";
+import { Button } from "@features/ui";
+
+export function ProjectError() {
+  return (
+    <div className={styles["error-container"]}>
+      <div className={styles["left-banner"]}>
+        <div>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={"/icons/alert-circle.svg"}
+            alt="alert icon"
+            className={styles["alert-circle"]}
+          />
+        </div>
+        <p>There was a problem while loading the project data</p>
+      </div>
+
+      {/*will need to be a button*/}
+      <Button className={styles["right-banner"]}>
+        <p>Try again</p>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={"/icons/arrow-right.svg"}
+          alt="arrow"
+          className={styles["error-arrow"]}
+        />
+      </Button>
+    </div>
+  );
+}

--- a/features/projects/components/project-error/project-error.tsx
+++ b/features/projects/components/project-error/project-error.tsx
@@ -1,7 +1,11 @@
 import styles from "./project-error.module.scss";
 import { Button } from "@features/ui";
 
-export function ProjectError() {
+export type ProjectErrorProps = {
+  onRetry: () => void;
+};
+
+export function ProjectError({ onRetry }: ProjectErrorProps) {
   return (
     <div className={styles["error-container"]}>
       <div className={styles["left-banner"]}>
@@ -17,7 +21,7 @@ export function ProjectError() {
       </div>
 
       {/*will need to be a button*/}
-      <Button className={styles["right-banner"]}>
+      <Button className={styles["right-banner"]} onClick={onRetry}>
         <p>Try again</p>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img

--- a/features/projects/components/project-list/project-list.tsx
+++ b/features/projects/components/project-list/project-list.tsx
@@ -2,9 +2,10 @@ import { ProjectCard } from "../project-card";
 import { useGetProjects } from "../../api/use-get-projects";
 import styles from "./project-list.module.scss";
 import { LoadingScreen } from "@features/ui";
+import { ProjectError } from "../project-error";
 
 export function ProjectList() {
-  const { data, isLoading, isError, error } = useGetProjects();
+  const { data, isLoading, isError, error, refetch } = useGetProjects();
 
   if (isLoading) {
     return (
@@ -19,7 +20,11 @@ export function ProjectList() {
 
   if (isError) {
     console.error(error);
-    return <div>Error: {error.message}</div>;
+    return (
+      <div data-testid="project-error">
+        <ProjectError onRetry={refetch} />
+      </div>
+    );
   }
 
   return (

--- a/public/icons/alert-circle.svg
+++ b/public/icons/alert-circle.svg
@@ -1,0 +1,10 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_644_24329)">
+<path d="M9.99999 6.66663V9.99996M9.99999 13.3333H10.0083M18.3333 9.99996C18.3333 14.6023 14.6024 18.3333 9.99999 18.3333C5.39762 18.3333 1.66666 14.6023 1.66666 9.99996C1.66666 5.39759 5.39762 1.66663 9.99999 1.66663C14.6024 1.66663 18.3333 5.39759 18.3333 9.99996Z" stroke="#D92D20" stroke-width="1.66667" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_644_24329">
+<rect width="20" height="20" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/icons/arrow-right.svg
+++ b/public/icons/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.16669 7.00008H12.8334M12.8334 7.00008L7.00002 1.16675M12.8334 7.00008L7.00002 12.8334" stroke="#B42318" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
### User Story
As a user I want to see an error message when the request fails so that I know that there was a problem.

### Design
![image](https://github.com/profydev/prolog-app-jaclynmariefrench/assets/77642588/82098837-9b29-4378-ae03-a11237de50d6)
[Design on figma](https://www.figma.com/file/8ZmbMRC8PtvXx7L5PjVcVM/Prolog?node-id=644%3A22599))

### Testing Acceptance Criteria

- [ ] The error message is displayed when the request fails

- [ ] The data is reloaded when the “Try again” button is clicked

- [ ] Covered by a Cypress test

### Trick to test
Go into Chrome dev tools and:

1. Click "Network" tab

2. Click "Fetch/XHR" tab 

<img width="148" alt="Screenshot 2024-03-22 at 2 30 35 PM" src="https://github.com/profydev/prolog-app-jaclynmariefrench/assets/77642588/b7c96f80-2039-46ea-b3f4-1a98e451cb4a">

3. Right click project and click the block URL option

<img width="252" alt="Screenshot 2024-03-22 at 2 31 25 PM" src="https://github.com/profydev/prolog-app-jaclynmariefrench/assets/77642588/0f6b3b36-2948-481f-811d-98d692bf6759">

4. Refresh the page and the error message should pop up if working correctly
