### PR TITLE
Issue list filters

### DIFF
--- a/api/issues.ts
+++ b/api/issues.ts
@@ -4,19 +4,14 @@ import type { Page } from "@typings/page.types";
 
 const ENDPOINT = "/issue";
 
-type Options = {
-  signal?: AbortSignal;
-  status?: "unresolved" | "resolved" | "open" | undefined;
-};
-
-export async function getIssues(page: number, options?: Options) {
-  let { status } = options || {};
-  if (status === "unresolved") {
-    status = "open";
-  }
-
+export async function getIssues(
+  page: number,
+  status?: string,
+  level?: string,
+  options?: { signal?: AbortSignal },
+) {
   const { data } = await axios.get<Page<Issue>>(ENDPOINT, {
-    params: { page, status },
+    params: { page, status, level },
     signal: options?.signal,
   });
   return data;

--- a/api/issues.ts
+++ b/api/issues.ts
@@ -4,12 +4,19 @@ import type { Page } from "@typings/page.types";
 
 const ENDPOINT = "/issue";
 
-export async function getIssues(
-  page: number,
-  options?: { signal?: AbortSignal },
-) {
+type Options = {
+  signal?: AbortSignal;
+  status?: "unresolved" | "resolved" | "open" | undefined;
+};
+
+export async function getIssues(page: number, options?: Options) {
+  let { status } = options || {};
+  if (status === "unresolved") {
+    status = "open";
+  }
+
   const { data } = await axios.get<Page<Issue>>(ENDPOINT, {
-    params: { page },
+    params: { page, status },
     signal: options?.signal,
   });
   return data;

--- a/api/issues.ts
+++ b/api/issues.ts
@@ -8,10 +8,11 @@ export async function getIssues(
   page: number,
   status?: string,
   level?: string,
+  project?: string,
   options?: { signal?: AbortSignal },
 ) {
   const { data } = await axios.get<Page<Issue>>(ENDPOINT, {
-    params: { page, status, level },
+    params: { page, status, level, project },
     signal: options?.signal,
   });
   return data;

--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -15,8 +15,8 @@ export type Issue = {
   name: string;
   message: string;
   stack: string;
-  level: IssueLevel;
+  level: IssueLevel | undefined;
   numEvents: number;
   numUsers: number;
-  status: IssueStatus;
+  status: IssueStatus | undefined;
 };

--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -4,6 +4,11 @@ export enum IssueLevel {
   error = "error",
 }
 
+export enum IssueStatus {
+  open = "open",
+  resolved = "resolved",
+}
+
 export type Issue = {
   id: string;
   projectId: string;
@@ -13,4 +18,5 @@ export type Issue = {
   level: IssueLevel;
   numEvents: number;
   numUsers: number;
+  status: IssueStatus;
 };

--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -5,7 +5,7 @@ export enum IssueLevel {
 }
 
 export enum IssueStatus {
-  open = "open",
+  unresolved = "unresolved",
   resolved = "resolved",
 }
 

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -1,14 +1,8 @@
 import mockIssues1 from "../fixtures/issues-page-1.json";
 import mockIssues2 from "../fixtures/issues-page-2.json";
 import mockIssues3 from "../fixtures/issues-page-3.json";
-
-// Allows filtering for “Unresolved” and “Resolved” issues
-// Allows filtering for level “Error”, “Warning”, and “Info”
-// Allows filtering for any existing project by (partial) project name
-// Every dropdown can be empty (no value selected) to remove a filter
-// Issues are displayed according to the filters
-// Each filter should persist after the page is refreshed
-// The user should be able to share the page including the currently selected filters
+import filteredWarning from "../fixtures/issues-page-filter-warning.json";
+import filteredUnresolved from "../fixtures/issues-page-filter-unresolved.json";
 
 describe("Issue List", () => {
   beforeEach(() => {
@@ -16,15 +10,31 @@ describe("Issue List", () => {
     cy.intercept("GET", "https://prolog-api.profy.dev/project", {
       fixture: "projects.json",
     }).as("getProjects");
-    cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=1*", {
-      fixture: "issues-page-1.json",
-    }).as("getIssuesPage1");
-    cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=2*", {
-      fixture: "issues-page-2.json",
-    }).as("getIssuesPage2");
-    cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=3*", {
-      fixture: "issues-page-3.json",
-    }).as("getIssuesPage3");
+
+    cy.intercept(
+      "GET",
+      /https:\/\/prolog-api\.profy\.dev\/issue\?page=(\d+)/,
+      (req) => {
+        const url = new URL(req.url);
+        const page = url.searchParams.get("page");
+        const level = url.searchParams.get("level");
+        const status = url.searchParams.get("status");
+
+        if (level === "warning" && status === "open") {
+          req.reply({ fixture: "issues-page-filter-unresolved.json" });
+        } else if (level === "warning") {
+          req.reply({ fixture: "issues-page-filter-warning.json" });
+        } else if (status === "unresolved") {
+          req.reply({ fixture: "issues-page-filter-unresolved.json" });
+        } else if (page === "1") {
+          req.reply({ fixture: "issues-page-1.json" });
+        } else if (page === "2") {
+          req.reply({ fixture: "issues-page-2.json" });
+        } else if (page === "3") {
+          req.reply({ fixture: "issues-page-3.json" });
+        }
+      },
+    ).as("getIssues");
 
     // wait for intercepts to be set up
     cy.wait(0);
@@ -33,7 +43,7 @@ describe("Issue List", () => {
     cy.visit(`http://localhost:3000/dashboard/issues`);
 
     // wait for request to resolve
-    cy.wait(["@getProjects", "@getIssuesPage1"]);
+    cy.wait(["@getProjects", "@getIssues"]);
     cy.wait(500);
 
     // set button aliases
@@ -68,34 +78,237 @@ describe("Issue List", () => {
 
       // test navigation to second page
       cy.get("@next-button").click();
-      cy.wait("@getIssuesPage2");
+      cy.wait("@getIssues");
       cy.get("@prev-button").should("not.have.attr", "disabled");
       cy.contains("Page 2 of 3");
       cy.get("tbody tr:first").contains(mockIssues2.items[0].message);
 
       // test navigation to third and last page
       cy.get("@next-button").click();
-      cy.wait("@getIssuesPage3");
+      cy.wait("@getIssues");
       cy.get("@next-button").should("have.attr", "disabled");
       cy.contains("Page 3 of 3");
       cy.get("tbody tr:first").contains(mockIssues3.items[0].message);
 
       // test navigation back to second page
       cy.get("@prev-button").click();
-      cy.wait("@getIssuesPage2");
+      cy.wait("@getIssues");
       cy.get("@next-button").should("not.have.attr", "disabled");
       cy.contains("Page 2 of 3");
       cy.get("tbody tr:first").contains(mockIssues2.items[0].message);
     });
 
-    it("persists page after reload", () => {
-      cy.get("@next-button").click();
-      cy.contains("Page 2 of 3");
+    it("filtering is working", () => {
+      // simulate user actions that trigger the filters testing level filter
+      cy.get('[data-testid="level-select"]').click();
+      cy.get(
+        '[data-testid="level-select"] [data-testid="select-option-2"]',
+      ).click();
+      cy.wait("@getIssues");
+      // Check that no pagination is displayed
+      cy.get("@next-button").should("have.attr", "disabled");
+      cy.get("@prev-button").should("have.attr", "disabled");
+      cy.get("main")
+        .find("tbody")
+        .find("tr")
+        .each(($el, index) => {
+          const issue = filteredWarning.items[index];
+          const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
+          cy.wrap($el).contains(issue.name);
+          cy.wrap($el).contains(issue.message);
+          cy.wrap($el).contains(issue.numEvents);
+          cy.wrap($el).contains(issue.numUsers);
+          cy.wrap($el).contains(firstLineOfStackTrace);
+        });
 
-      cy.reload();
-      cy.wait(["@getProjects", "@getIssuesPage2"]);
-      cy.wait(1500);
-      cy.contains("Page 2 of 3");
+      // simulate filtering to unresolved
+      cy.get('[data-testid="status-select"]').click();
+      cy.get(
+        '[data-testid="status-select"] [data-testid="select-option-1"]',
+      ).click();
+      cy.wait("@getIssues");
+      // Check that no pagination is displayed
+      cy.get("@next-button").should("have.attr", "disabled");
+      cy.get("@prev-button").should("have.attr", "disabled");
+      cy.get("main")
+        .find("tbody")
+        .find("tr")
+        .each(($el, index) => {
+          const issue = filteredUnresolved.items[index];
+          if (issue) {
+            const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
+            console.log(firstLineOfStackTrace);
+            cy.wrap($el).contains(issue.name);
+            cy.wrap($el).contains(issue.message);
+            cy.wrap($el).contains(issue.numEvents);
+            cy.wrap($el).contains(issue.numUsers);
+            cy.wrap($el).contains(firstLineOfStackTrace);
+          }
+        });
+      // simulate filtering to project id
+      cy.get('[data-testid="status-select"]').click();
+      cy.get(
+        '[data-testid="status-select"] [data-testid="select-option-1"]',
+      ).click();
+      cy.wait("@getIssues");
+      // Check that no pagination is displayed
+      cy.get("@next-button").should("have.attr", "disabled");
+      cy.get("@prev-button").should("have.attr", "disabled");
+      cy.get("main")
+        .find("tbody")
+        .find("tr")
+        .each(($el, index) => {
+          const issue = filteredUnresolved.items[index];
+          if (issue) {
+            const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
+            console.log(firstLineOfStackTrace);
+            cy.wrap($el).contains(issue.name);
+            cy.wrap($el).contains(issue.message);
+            cy.wrap($el).contains(issue.numEvents);
+            cy.wrap($el).contains(issue.numUsers);
+            cy.wrap($el).contains(firstLineOfStackTrace);
+          }
+        });
     });
   });
 });
+
+// import mockIssues1 from "../fixtures/issues-page-1.json";
+// import mockIssues2 from "../fixtures/issues-page-2.json";
+// import mockIssues3 from "../fixtures/issues-page-3.json";
+// // import filterMockWarning from "../fixtures/issues-page-filter-warning.json";
+// // import filterMockUnresolved from "../fixtures/issues-page-filter-unresolved.json";
+// // import filterMockProjectSearch from "../fixtures/issues-page-filter-project-search.json";
+
+// describe("Issue List", () => {
+//   beforeEach(() => {
+//     // setup request mocks
+//     cy.intercept("GET", "https://prolog-api.profy.dev/project", {
+//       fixture: "projects.json",
+//     }).as("getProjects");
+//     cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=1", {
+//       fixture: "issues-page-1.json",
+//     }).as("getIssuesPage1");
+//     cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=2*", {
+//       fixture: "issues-page-2.json",
+//     }).as("getIssuesPage2");
+//     cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=3*", {
+//       fixture: "issues-page-3.json",
+//     }).as("getIssuesPage3");
+
+//     // wait for intercepts to be set up
+//     cy.wait(0);
+
+//     // open issues page
+//     cy.visit(`http://localhost:3000/dashboard/issues`);
+
+//     // wait for request to resolve
+//     cy.wait(["@getProjects", "@getIssuesPage1"]);
+//     cy.wait(500);
+
+//     // set button aliases
+//     cy.get("button").contains("Previous").as("prev-button");
+//     cy.get("button").contains("Next").as("next-button");
+//   });
+
+//   context("desktop resolution", () => {
+//     beforeEach(() => {
+//       cy.viewport(1025, 900);
+//     });
+
+//     it("renders the issues", () => {
+//       cy.get("main")
+//         .find("tbody")
+//         .find("tr")
+//         .each(($el, index) => {
+//           const issue = mockIssues1.items[index];
+//           const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
+//           cy.wrap($el).contains(issue.name);
+//           cy.wrap($el).contains(issue.message);
+//           cy.wrap($el).contains(issue.numEvents);
+//           cy.wrap($el).contains(issue.numUsers);
+//           cy.wrap($el).contains(firstLineOfStackTrace);
+//         });
+//     });
+
+//     it("paginates the data", () => {
+//       // test first page
+//       cy.contains("Page 1 of 3");
+//       cy.get("@prev-button").should("have.attr", "disabled");
+
+//       // test navigation to second page
+//       cy.get("@next-button").click();
+//       cy.wait("@getIssuesPage2");
+//       cy.get("@prev-button").should("not.have.attr", "disabled");
+//       cy.contains("Page 2 of 3");
+//       cy.get("tbody tr:first").contains(mockIssues2.items[0].message);
+
+//       // test navigation to third and last page
+//       cy.get("@next-button").click();
+//       cy.wait("@getIssuesPage3");
+//       cy.get("@next-button").should("have.attr", "disabled");
+//       cy.contains("Page 3 of 3");
+//       cy.get("tbody tr:first").contains(mockIssues3.items[0].message);
+
+//       // test navigation back to second page
+//       cy.get("@prev-button").click();
+//       cy.wait("@getIssuesPage2");
+//       cy.get("@next-button").should("not.have.attr", "disabled");
+//       cy.contains("Page 2 of 3");
+//       cy.get("tbody tr:first").contains(mockIssues2.items[0].message);
+//     });
+
+//     it("filtering is working", () => {
+//       cy.intercept("GET", "https://prolog-api.profy.dev/issue?level=warning*", {
+//         fixture: "issues-page-filter-warning.json",
+//       }).as("getIssueFilterWarning");
+//       // cy.intercept(
+//       //   "GET",
+//       //   "https://prolog-api.profy.dev/issue?status=unresolved*",
+//       //   {
+//       //     fixture: "issue-page-filter-unresolved.json",
+//       //   },
+//       // ).as("getIssueFilterUnresolved");
+//       // cy.intercept(
+//       //   "GET",
+//       //   "https://prolog-api.profy.dev/issue?status=unresolved&project=front*",
+//       //   {
+//       //     fixture: "issue-page-filter-project-search.json",
+//       //   },
+//       // ).as("getIssueFilterSearch");
+
+//       // simulate user actions that trigger the filters
+//       cy.get('[data-testid="level-select"]').click();
+//       cy.get(
+//         '[data-testid="level-select"] [data-testid="select-option-2"]',
+//       ).click();
+//       // cy.wait("@getIssueFilterWarning");
+
+//       // Check that no pagination is displayed
+//       // cy.get("@prev-button").should("not.exist");
+//       // cy.get("@next-button").should("not.exist");
+
+//       // Check that no pagination is displayed
+//       // cy.get("@prev-button").should("not.exist");
+//       // cy.get("@next-button").should("not.exist");
+//       // cy.get('[data-testid="level-select"]').click();
+//       // Wait for the options to be visible
+//       // cy.wait(1000); // Adjust the wait time as needed
+
+//       // cy.get('[data-testid="status-select"] [data-testid="select-option-0"]')
+//       //   .should("be.visible")
+//       //   .then(($option) => {
+//       //     cy.log("Found the option", $option);
+//       //   })
+//       //   .click();
+//     });
+//   });
+// });
+
+// // Allows filtering for “Unresolved” and “Resolved” issues
+// // Allows filtering for level “Error”, “Warning”, and “Info”
+// // Allows filtering for any existing project by (partial) project name
+// // Every dropdown can be empty (no value selected) to remove a filter
+// // Issues are displayed according to the filters
+// // Each filter should persist after the page is refreshed
+// // The user should be able to share the page including the currently selected filters

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -2,21 +2,32 @@ import mockIssues1 from "../fixtures/issues-page-1.json";
 import mockIssues2 from "../fixtures/issues-page-2.json";
 import mockIssues3 from "../fixtures/issues-page-3.json";
 
+// Allows filtering for “Unresolved” and “Resolved” issues
+// Allows filtering for level “Error”, “Warning”, and “Info”
+// Allows filtering for any existing project by (partial) project name
+// Every dropdown can be empty (no value selected) to remove a filter
+// Issues are displayed according to the filters
+// Each filter should persist after the page is refreshed
+// The user should be able to share the page including the currently selected filters
+
 describe("Issue List", () => {
   beforeEach(() => {
     // setup request mocks
     cy.intercept("GET", "https://prolog-api.profy.dev/project", {
       fixture: "projects.json",
     }).as("getProjects");
-    cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=1", {
+    cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=1*", {
       fixture: "issues-page-1.json",
     }).as("getIssuesPage1");
-    cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=2", {
+    cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=2*", {
       fixture: "issues-page-2.json",
     }).as("getIssuesPage2");
-    cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=3", {
+    cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=3*", {
       fixture: "issues-page-3.json",
     }).as("getIssuesPage3");
+
+    // wait for intercepts to be set up
+    cy.wait(0);
 
     // open issues page
     cy.visit(`http://localhost:3000/dashboard/issues`);
@@ -57,18 +68,21 @@ describe("Issue List", () => {
 
       // test navigation to second page
       cy.get("@next-button").click();
+      cy.wait("@getIssuesPage2");
       cy.get("@prev-button").should("not.have.attr", "disabled");
       cy.contains("Page 2 of 3");
       cy.get("tbody tr:first").contains(mockIssues2.items[0].message);
 
       // test navigation to third and last page
       cy.get("@next-button").click();
+      cy.wait("@getIssuesPage3");
       cy.get("@next-button").should("have.attr", "disabled");
       cy.contains("Page 3 of 3");
       cy.get("tbody tr:first").contains(mockIssues3.items[0].message);
 
       // test navigation back to second page
       cy.get("@prev-button").click();
+      cy.wait("@getIssuesPage2");
       cy.get("@next-button").should("not.have.attr", "disabled");
       cy.contains("Page 2 of 3");
       cy.get("tbody tr:first").contains(mockIssues2.items[0].message);

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -4,6 +4,18 @@ import mockIssues3 from "../fixtures/issues-page-3.json";
 import filteredWarning from "../fixtures/issues-page-filter-warning.json";
 import filteredUnresolved from "../fixtures/issues-page-filter-unresolved.json";
 import filteredSearch from "../fixtures/issues-page-filter-project-search.json";
+import filteredClearSelect from "../fixtures/issues-page-filter-clear-select.json";
+
+const fixtureMap = {
+  warning_open_fro: filteredSearch,
+  warning_open: filteredUnresolved,
+  warning: filteredWarning,
+  unresolved: filteredUnresolved,
+  cleared_open_fro: filteredClearSelect,
+  "1": mockIssues1,
+  "2": mockIssues2,
+  "3": mockIssues3,
+};
 
 describe("Issue List", () => {
   beforeEach(() => {
@@ -18,24 +30,22 @@ describe("Issue List", () => {
       (req) => {
         const url = new URL(req.url);
         const page = url.searchParams.get("page");
-        const level = url.searchParams.get("level");
+        const level = url.searchParams.get("level") || "cleared";
         const status = url.searchParams.get("status");
         const project = url.searchParams.get("project");
 
-        if (level === "warning" && status === "open" && project === "fro") {
-          req.reply({ fixture: "issues-page-filter-project-search.json" });
-        } else if (level === "warning" && status === "open") {
-          req.reply({ fixture: "issues-page-filter-unresolved.json" });
-        } else if (level === "warning") {
-          req.reply({ fixture: "issues-page-filter-warning.json" });
-        } else if (status === "unresolved") {
-          req.reply({ fixture: "issues-page-filter-unresolved.json" });
-        } else if (page === "1") {
-          req.reply({ fixture: "issues-page-1.json" });
-        } else if (page === "2") {
-          req.reply({ fixture: "issues-page-2.json" });
-        } else if (page === "3") {
-          req.reply({ fixture: "issues-page-3.json" });
+        // Generate the key for the fixture map
+        const key = [level, status, project].filter(Boolean).join("_");
+        const fixture =
+          fixtureMap[key as keyof typeof fixtureMap] ||
+          fixtureMap[page as keyof typeof fixtureMap];
+
+        console.log("Request parameters:", { page, level, status, project });
+        console.log("Generated key:", key);
+        console.log("Fixture map:", fixtureMap);
+
+        if (fixture) {
+          req.reply({ body: fixture });
         }
       },
     ).as("getIssues");
@@ -124,6 +134,7 @@ describe("Issue List", () => {
           cy.wrap($el).contains(issue.numUsers);
           cy.wrap($el).contains(firstLineOfStackTrace);
         });
+      cy.url().should("include", "issues?level=warning");
 
       // simulate filtering to unresolved
       cy.get('[data-testid="status-select"]').click();
@@ -149,8 +160,12 @@ describe("Issue List", () => {
             cy.wrap($el).contains(firstLineOfStackTrace);
           }
         });
+      cy.url().should("include", "issues?level=warning&status=unresolved");
+
       // simulate filtering to project id
-      cy.get('[data-testid="search-input"]').type("fro");
+      cy.get('[data-testid="search-input"]')
+        .clear()
+        .type("fro", { delay: 700 });
       cy.wait("@getIssues");
       // Check that no pagination is displayed
       cy.get("@next-button").should("have.attr", "disabled");
@@ -169,146 +184,39 @@ describe("Issue List", () => {
             cy.wrap($el).contains(firstLineOfStackTrace);
           }
         });
+      cy.url().should(
+        "include",
+        "issues?level=warning&status=unresolved&project=fro",
+      );
+
+      //test page reload
+      cy.reload();
+      cy.url().should(
+        "include",
+        "issues?level=warning&status=unresolved&project=fro",
+      );
+
+      //dropdowns empty to remove a filter
+      cy.get('[data-testid="level-select"]').click();
+      cy.get(
+        '[data-testid="level-select"] [data-testid="select-option-0"]',
+      ).click();
+      cy.wait("@getIssues");
+      cy.get("main")
+        .find("tbody")
+        .find("tr")
+        .each(($el, index) => {
+          const issue = filteredClearSelect.items[index];
+          if (issue) {
+            const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
+            cy.wrap($el).contains(issue.name);
+            cy.wrap($el).contains(issue.message);
+            cy.wrap($el).contains(issue.numEvents);
+            cy.wrap($el).contains(issue.numUsers);
+            cy.wrap($el).contains(firstLineOfStackTrace);
+          }
+        });
+      cy.url().should("include", "issues?level=&status=unresolved&project=fro");
     });
   });
 });
-
-// import mockIssues1 from "../fixtures/issues-page-1.json";
-// import mockIssues2 from "../fixtures/issues-page-2.json";
-// import mockIssues3 from "../fixtures/issues-page-3.json";
-// // import filterMockWarning from "../fixtures/issues-page-filter-warning.json";
-// // import filterMockUnresolved from "../fixtures/issues-page-filter-unresolved.json";
-// // import filterMockProjectSearch from "../fixtures/issues-page-filter-project-search.json";
-
-// describe("Issue List", () => {
-//   beforeEach(() => {
-//     // setup request mocks
-//     cy.intercept("GET", "https://prolog-api.profy.dev/project", {
-//       fixture: "projects.json",
-//     }).as("getProjects");
-//     cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=1", {
-//       fixture: "issues-page-1.json",
-//     }).as("getIssuesPage1");
-//     cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=2*", {
-//       fixture: "issues-page-2.json",
-//     }).as("getIssuesPage2");
-//     cy.intercept("GET", "https://prolog-api.profy.dev/issue?page=3*", {
-//       fixture: "issues-page-3.json",
-//     }).as("getIssuesPage3");
-
-//     // wait for intercepts to be set up
-//     cy.wait(0);
-
-//     // open issues page
-//     cy.visit(`http://localhost:3000/dashboard/issues`);
-
-//     // wait for request to resolve
-//     cy.wait(["@getProjects", "@getIssuesPage1"]);
-//     cy.wait(500);
-
-//     // set button aliases
-//     cy.get("button").contains("Previous").as("prev-button");
-//     cy.get("button").contains("Next").as("next-button");
-//   });
-
-//   context("desktop resolution", () => {
-//     beforeEach(() => {
-//       cy.viewport(1025, 900);
-//     });
-
-//     it("renders the issues", () => {
-//       cy.get("main")
-//         .find("tbody")
-//         .find("tr")
-//         .each(($el, index) => {
-//           const issue = mockIssues1.items[index];
-//           const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
-//           cy.wrap($el).contains(issue.name);
-//           cy.wrap($el).contains(issue.message);
-//           cy.wrap($el).contains(issue.numEvents);
-//           cy.wrap($el).contains(issue.numUsers);
-//           cy.wrap($el).contains(firstLineOfStackTrace);
-//         });
-//     });
-
-//     it("paginates the data", () => {
-//       // test first page
-//       cy.contains("Page 1 of 3");
-//       cy.get("@prev-button").should("have.attr", "disabled");
-
-//       // test navigation to second page
-//       cy.get("@next-button").click();
-//       cy.wait("@getIssuesPage2");
-//       cy.get("@prev-button").should("not.have.attr", "disabled");
-//       cy.contains("Page 2 of 3");
-//       cy.get("tbody tr:first").contains(mockIssues2.items[0].message);
-
-//       // test navigation to third and last page
-//       cy.get("@next-button").click();
-//       cy.wait("@getIssuesPage3");
-//       cy.get("@next-button").should("have.attr", "disabled");
-//       cy.contains("Page 3 of 3");
-//       cy.get("tbody tr:first").contains(mockIssues3.items[0].message);
-
-//       // test navigation back to second page
-//       cy.get("@prev-button").click();
-//       cy.wait("@getIssuesPage2");
-//       cy.get("@next-button").should("not.have.attr", "disabled");
-//       cy.contains("Page 2 of 3");
-//       cy.get("tbody tr:first").contains(mockIssues2.items[0].message);
-//     });
-
-//     it("filtering is working", () => {
-//       cy.intercept("GET", "https://prolog-api.profy.dev/issue?level=warning*", {
-//         fixture: "issues-page-filter-warning.json",
-//       }).as("getIssueFilterWarning");
-//       // cy.intercept(
-//       //   "GET",
-//       //   "https://prolog-api.profy.dev/issue?status=unresolved*",
-//       //   {
-//       //     fixture: "issue-page-filter-unresolved.json",
-//       //   },
-//       // ).as("getIssueFilterUnresolved");
-//       // cy.intercept(
-//       //   "GET",
-//       //   "https://prolog-api.profy.dev/issue?status=unresolved&project=front*",
-//       //   {
-//       //     fixture: "issue-page-filter-project-search.json",
-//       //   },
-//       // ).as("getIssueFilterSearch");
-
-//       // simulate user actions that trigger the filters
-//       cy.get('[data-testid="level-select"]').click();
-//       cy.get(
-//         '[data-testid="level-select"] [data-testid="select-option-2"]',
-//       ).click();
-//       // cy.wait("@getIssueFilterWarning");
-
-//       // Check that no pagination is displayed
-//       // cy.get("@prev-button").should("not.exist");
-//       // cy.get("@next-button").should("not.exist");
-
-//       // Check that no pagination is displayed
-//       // cy.get("@prev-button").should("not.exist");
-//       // cy.get("@next-button").should("not.exist");
-//       // cy.get('[data-testid="level-select"]').click();
-//       // Wait for the options to be visible
-//       // cy.wait(1000); // Adjust the wait time as needed
-
-//       // cy.get('[data-testid="status-select"] [data-testid="select-option-0"]')
-//       //   .should("be.visible")
-//       //   .then(($option) => {
-//       //     cy.log("Found the option", $option);
-//       //   })
-//       //   .click();
-//     });
-//   });
-// });
-
-// // Allows filtering for “Unresolved” and “Resolved” issues
-// // Allows filtering for level “Error”, “Warning”, and “Info”
-// // Allows filtering for any existing project by (partial) project name
-// // Every dropdown can be empty (no value selected) to remove a filter
-// // Issues are displayed according to the filters
-// // Each filter should persist after the page is refreshed
-// // The user should be able to share the page including the currently selected filters

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -40,10 +40,6 @@ describe("Issue List", () => {
           fixtureMap[key as keyof typeof fixtureMap] ||
           fixtureMap[page as keyof typeof fixtureMap];
 
-        console.log("Request parameters:", { page, level, status, project });
-        console.log("Generated key:", key);
-        console.log("Fixture map:", fixtureMap);
-
         if (fixture) {
           req.reply({ body: fixture });
         }

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -124,11 +124,12 @@ describe("Issue List", () => {
         .each(($el, index) => {
           const issue = filteredWarning.items[index];
           const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
-          cy.wrap($el).contains(issue.name);
-          cy.wrap($el).contains(issue.message);
-          cy.wrap($el).contains(issue.numEvents);
-          cy.wrap($el).contains(issue.numUsers);
-          cy.wrap($el).contains(firstLineOfStackTrace);
+          cy.wrap($el).as("currentEl");
+          cy.get("@currentEl").contains(issue.name);
+          cy.get("@currentEl").contains(issue.message);
+          cy.get("@currentEl").contains(issue.numEvents);
+          cy.get("@currentEl").contains(issue.numUsers);
+          cy.get("@currentEl").contains(firstLineOfStackTrace);
         });
       cy.url().should("include", "issues?level=warning");
 
@@ -148,12 +149,12 @@ describe("Issue List", () => {
           const issue = filteredUnresolved.items[index];
           if (issue) {
             const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
-            console.log(firstLineOfStackTrace);
-            cy.wrap($el).contains(issue.name);
-            cy.wrap($el).contains(issue.message);
-            cy.wrap($el).contains(issue.numEvents);
-            cy.wrap($el).contains(issue.numUsers);
-            cy.wrap($el).contains(firstLineOfStackTrace);
+            cy.wrap($el).as("currentEl");
+            cy.get("@currentEl").contains(issue.name);
+            cy.get("@currentEl").contains(issue.message);
+            cy.get("@currentEl").contains(issue.numEvents);
+            cy.get("@currentEl").contains(issue.numUsers);
+            cy.get("@currentEl").contains(firstLineOfStackTrace);
           }
         });
       cy.url().should("include", "issues?level=warning&status=unresolved");
@@ -173,11 +174,12 @@ describe("Issue List", () => {
           const issue = filteredSearch.items[index];
           if (issue) {
             const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
-            cy.wrap($el).contains(issue.name);
-            cy.wrap($el).contains(issue.message);
-            cy.wrap($el).contains(issue.numEvents);
-            cy.wrap($el).contains(issue.numUsers);
-            cy.wrap($el).contains(firstLineOfStackTrace);
+            cy.wrap($el).as("currentEl");
+            cy.get("@currentEl").contains(issue.name);
+            cy.get("@currentEl").contains(issue.message);
+            cy.get("@currentEl").contains(issue.numEvents);
+            cy.get("@currentEl").contains(issue.numUsers);
+            cy.get("@currentEl").contains(firstLineOfStackTrace);
           }
         });
       cy.url().should(
@@ -205,11 +207,12 @@ describe("Issue List", () => {
           const issue = filteredClearSelect.items[index];
           if (issue) {
             const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
-            cy.wrap($el).contains(issue.name);
-            cy.wrap($el).contains(issue.message);
-            cy.wrap($el).contains(issue.numEvents);
-            cy.wrap($el).contains(issue.numUsers);
-            cy.wrap($el).contains(firstLineOfStackTrace);
+            cy.wrap($el).as("currentEl");
+            cy.get("@currentEl").contains(issue.name);
+            cy.get("@currentEl").contains(issue.message);
+            cy.get("@currentEl").contains(issue.numEvents);
+            cy.get("@currentEl").contains(issue.numUsers);
+            cy.get("@currentEl").contains(firstLineOfStackTrace);
           }
         });
       cy.url().should("include", "issues?level=&status=unresolved&project=fro");

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -3,6 +3,7 @@ import mockIssues2 from "../fixtures/issues-page-2.json";
 import mockIssues3 from "../fixtures/issues-page-3.json";
 import filteredWarning from "../fixtures/issues-page-filter-warning.json";
 import filteredUnresolved from "../fixtures/issues-page-filter-unresolved.json";
+import filteredSearch from "../fixtures/issues-page-filter-project-search.json";
 
 describe("Issue List", () => {
   beforeEach(() => {
@@ -19,8 +20,11 @@ describe("Issue List", () => {
         const page = url.searchParams.get("page");
         const level = url.searchParams.get("level");
         const status = url.searchParams.get("status");
+        const project = url.searchParams.get("project");
 
-        if (level === "warning" && status === "open") {
+        if (level === "warning" && status === "open" && project === "fro") {
+          req.reply({ fixture: "issues-page-filter-project-search.json" });
+        } else if (level === "warning" && status === "open") {
           req.reply({ fixture: "issues-page-filter-unresolved.json" });
         } else if (level === "warning") {
           req.reply({ fixture: "issues-page-filter-warning.json" });
@@ -146,10 +150,7 @@ describe("Issue List", () => {
           }
         });
       // simulate filtering to project id
-      cy.get('[data-testid="status-select"]').click();
-      cy.get(
-        '[data-testid="status-select"] [data-testid="select-option-1"]',
-      ).click();
+      cy.get('[data-testid="search-input"]').type("fro");
       cy.wait("@getIssues");
       // Check that no pagination is displayed
       cy.get("@next-button").should("have.attr", "disabled");
@@ -158,10 +159,9 @@ describe("Issue List", () => {
         .find("tbody")
         .find("tr")
         .each(($el, index) => {
-          const issue = filteredUnresolved.items[index];
+          const issue = filteredSearch.items[index];
           if (issue) {
             const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
-            console.log(firstLineOfStackTrace);
             cy.wrap($el).contains(issue.name);
             cy.wrap($el).contains(issue.message);
             cy.wrap($el).contains(issue.numEvents);

--- a/cypress/fixtures/issues-page-filter-clear-select.json
+++ b/cypress/fixtures/issues-page-filter-clear-select.json
@@ -1,80 +1,79 @@
 {
-    "items": [
-      {
-        "id": "d4febf2b-022e-45ff-a70b-cea24234f8b5",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "TypeError",
-        "message": "can't define property F: \"obj\" is not extensible",
-        "stack": "can't define property \"x\": \"obj\" is not extensible\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "error",
-        "status": "open",
-        "numEvents": 31,
-        "numUsers": 21
-      },
-      {
-        "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "TypeError",
-        "message": "setting getter-only property R",
-        "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "warning",
-        "status": "open",
-        "numEvents": 26,
-        "numUsers": 24
-      },
-      {
-        "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "ReferenceError",
-        "message": "C is not defined",
-        "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "warning",
-        "status": "open",
-        "numEvents": 12,
-        "numUsers": 11
-      },
+  "items": [
+    {
+      "id": "d4febf2b-022e-45ff-a70b-cea24234f8b5",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "TypeError",
+      "message": "can't define property F: \"obj\" is not extensible",
+      "stack": "can't define property \"x\": \"obj\" is not extensible\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "error",
+      "status": "open",
+      "numEvents": 31,
+      "numUsers": 21
+    },
+    {
+      "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "TypeError",
+      "message": "setting getter-only property R",
+      "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "warning",
+      "status": "open",
+      "numEvents": 26,
+      "numUsers": 24
+    },
+    {
+      "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "ReferenceError",
+      "message": "C is not defined",
+      "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "warning",
+      "status": "open",
+      "numEvents": 12,
+      "numUsers": 11
+    },
 
-      {
-        "id": "6e6151ee-74f7-4673-9441-7aead54b6ebd",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "SyntaxError",
-        "message": "Malformed formal parameter",
-        "stack": "Malformed formal parameter\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "info",
-        "status": "open",
-        "numEvents": 19,
-        "numUsers": 16
-      },
-      {
-        "id": "e06fac1f-7787-4088-b617-60a33e412694",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "SyntaxError",
-        "message": "test for equality (==) mistyped as assignment (=)?",
-        "stack": "test for equality (==) mistyped as assignment (=)?\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "error",
-        "status": "open",
-        "numEvents": 9,
-        "numUsers": 8
-      },
-      {
-        "id": "2e39a8a0-e34f-4f8b-a027-711e29e0c016",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "TypeError",
-        "message": "I is not a function",
-        "stack": "\"x\" is not a function\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "error",
-        "status": "open",
-        "numEvents": 18,
-        "numUsers": 16
-      }
-    ],
-    "meta": {
-      "currentPage": 1,
-      "limit": 10,
-      "totalItems": 6,
-      "totalPages": 1,
-      "hasPreviousPage": false,
-      "hasNextPage": false
+    {
+      "id": "6e6151ee-74f7-4673-9441-7aead54b6ebd",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "SyntaxError",
+      "message": "Malformed formal parameter",
+      "stack": "Malformed formal parameter\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "info",
+      "status": "open",
+      "numEvents": 19,
+      "numUsers": 16
+    },
+    {
+      "id": "e06fac1f-7787-4088-b617-60a33e412694",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "SyntaxError",
+      "message": "test for equality (==) mistyped as assignment (=)?",
+      "stack": "test for equality (==) mistyped as assignment (=)?\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "error",
+      "status": "open",
+      "numEvents": 9,
+      "numUsers": 8
+    },
+    {
+      "id": "2e39a8a0-e34f-4f8b-a027-711e29e0c016",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "TypeError",
+      "message": "I is not a function",
+      "stack": "\"x\" is not a function\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "error",
+      "status": "open",
+      "numEvents": 18,
+      "numUsers": 16
     }
+  ],
+  "meta": {
+    "currentPage": 1,
+    "limit": 10,
+    "totalItems": 6,
+    "totalPages": 1,
+    "hasPreviousPage": false,
+    "hasNextPage": false
   }
-  
+}

--- a/cypress/fixtures/issues-page-filter-clear-select.json
+++ b/cypress/fixtures/issues-page-filter-clear-select.json
@@ -1,0 +1,80 @@
+{
+    "items": [
+      {
+        "id": "d4febf2b-022e-45ff-a70b-cea24234f8b5",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "TypeError",
+        "message": "can't define property F: \"obj\" is not extensible",
+        "stack": "can't define property \"x\": \"obj\" is not extensible\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "error",
+        "status": "open",
+        "numEvents": 31,
+        "numUsers": 21
+      },
+      {
+        "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "TypeError",
+        "message": "setting getter-only property R",
+        "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "warning",
+        "status": "open",
+        "numEvents": 26,
+        "numUsers": 24
+      },
+      {
+        "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "ReferenceError",
+        "message": "C is not defined",
+        "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "warning",
+        "status": "open",
+        "numEvents": 12,
+        "numUsers": 11
+      },
+
+      {
+        "id": "6e6151ee-74f7-4673-9441-7aead54b6ebd",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "SyntaxError",
+        "message": "Malformed formal parameter",
+        "stack": "Malformed formal parameter\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "info",
+        "status": "open",
+        "numEvents": 19,
+        "numUsers": 16
+      },
+      {
+        "id": "e06fac1f-7787-4088-b617-60a33e412694",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "SyntaxError",
+        "message": "test for equality (==) mistyped as assignment (=)?",
+        "stack": "test for equality (==) mistyped as assignment (=)?\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "error",
+        "status": "open",
+        "numEvents": 9,
+        "numUsers": 8
+      },
+      {
+        "id": "2e39a8a0-e34f-4f8b-a027-711e29e0c016",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "TypeError",
+        "message": "I is not a function",
+        "stack": "\"x\" is not a function\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "error",
+        "status": "open",
+        "numEvents": 18,
+        "numUsers": 16
+      }
+    ],
+    "meta": {
+      "currentPage": 1,
+      "limit": 10,
+      "totalItems": 6,
+      "totalPages": 1,
+      "hasPreviousPage": false,
+      "hasNextPage": false
+    }
+  }
+  

--- a/cypress/fixtures/issues-page-filter-project-search.json
+++ b/cypress/fixtures/issues-page-filter-project-search.json
@@ -1,17 +1,6 @@
 {
     "items": [
       {
-        "id": "d4febf2b-022e-45ff-a70b-cea24234f8b5",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "TypeError",
-        "message": "can't define property F: \"obj\" is not extensible",
-        "stack": "can't define property \"x\": \"obj\" is not extensible\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "error",
-        "status": "open",
-        "numEvents": 31,
-        "numUsers": 21
-      },
-      {
         "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
         "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
         "name": "TypeError",
@@ -32,45 +21,12 @@
         "status": "open",
         "numEvents": 12,
         "numUsers": 11
-      },
-      {
-        "id": "6e6151ee-74f7-4673-9441-7aead54b6ebd",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "SyntaxError",
-        "message": "Malformed formal parameter",
-        "stack": "Malformed formal parameter\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "info",
-        "status": "open",
-        "numEvents": 19,
-        "numUsers": 16
-      },
-      {
-        "id": "e06fac1f-7787-4088-b617-60a33e412694",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "SyntaxError",
-        "message": "test for equality (==) mistyped as assignment (=)?",
-        "stack": "test for equality (==) mistyped as assignment (=)?\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "error",
-        "status": "open",
-        "numEvents": 9,
-        "numUsers": 8
-      },
-      {
-        "id": "2e39a8a0-e34f-4f8b-a027-711e29e0c016",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "TypeError",
-        "message": "I is not a function",
-        "stack": "\"x\" is not a function\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "error",
-        "status": "open",
-        "numEvents": 18,
-        "numUsers": 16
       }
     ],
     "meta": {
       "currentPage": 1,
       "limit": 10,
-      "totalItems": 6,
+      "totalItems": 2,
       "totalPages": 1,
       "hasPreviousPage": false,
       "hasNextPage": false

--- a/cypress/fixtures/issues-page-filter-project-search.json
+++ b/cypress/fixtures/issues-page-filter-project-search.json
@@ -1,35 +1,34 @@
 {
-    "items": [
-      {
-        "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "TypeError",
-        "message": "setting getter-only property R",
-        "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "warning",
-        "status": "open",
-        "numEvents": 26,
-        "numUsers": 24
-      },
-      {
-        "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "ReferenceError",
-        "message": "C is not defined",
-        "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "warning",
-        "status": "open",
-        "numEvents": 12,
-        "numUsers": 11
-      }
-    ],
-    "meta": {
-      "currentPage": 1,
-      "limit": 10,
-      "totalItems": 2,
-      "totalPages": 1,
-      "hasPreviousPage": false,
-      "hasNextPage": false
+  "items": [
+    {
+      "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "TypeError",
+      "message": "setting getter-only property R",
+      "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "warning",
+      "status": "open",
+      "numEvents": 26,
+      "numUsers": 24
+    },
+    {
+      "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "ReferenceError",
+      "message": "C is not defined",
+      "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "warning",
+      "status": "open",
+      "numEvents": 12,
+      "numUsers": 11
     }
+  ],
+  "meta": {
+    "currentPage": 1,
+    "limit": 10,
+    "totalItems": 2,
+    "totalPages": 1,
+    "hasPreviousPage": false,
+    "hasNextPage": false
   }
-  
+}

--- a/cypress/fixtures/issues-page-filter-project-search.json
+++ b/cypress/fixtures/issues-page-filter-project-search.json
@@ -1,0 +1,79 @@
+{
+    "items": [
+      {
+        "id": "d4febf2b-022e-45ff-a70b-cea24234f8b5",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "TypeError",
+        "message": "can't define property F: \"obj\" is not extensible",
+        "stack": "can't define property \"x\": \"obj\" is not extensible\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "error",
+        "status": "open",
+        "numEvents": 31,
+        "numUsers": 21
+      },
+      {
+        "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "TypeError",
+        "message": "setting getter-only property R",
+        "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "warning",
+        "status": "open",
+        "numEvents": 26,
+        "numUsers": 24
+      },
+      {
+        "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "ReferenceError",
+        "message": "C is not defined",
+        "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "warning",
+        "status": "open",
+        "numEvents": 12,
+        "numUsers": 11
+      },
+      {
+        "id": "6e6151ee-74f7-4673-9441-7aead54b6ebd",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "SyntaxError",
+        "message": "Malformed formal parameter",
+        "stack": "Malformed formal parameter\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "info",
+        "status": "open",
+        "numEvents": 19,
+        "numUsers": 16
+      },
+      {
+        "id": "e06fac1f-7787-4088-b617-60a33e412694",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "SyntaxError",
+        "message": "test for equality (==) mistyped as assignment (=)?",
+        "stack": "test for equality (==) mistyped as assignment (=)?\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "error",
+        "status": "open",
+        "numEvents": 9,
+        "numUsers": 8
+      },
+      {
+        "id": "2e39a8a0-e34f-4f8b-a027-711e29e0c016",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "TypeError",
+        "message": "I is not a function",
+        "stack": "\"x\" is not a function\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "error",
+        "status": "open",
+        "numEvents": 18,
+        "numUsers": 16
+      }
+    ],
+    "meta": {
+      "currentPage": 1,
+      "limit": 10,
+      "totalItems": 6,
+      "totalPages": 1,
+      "hasPreviousPage": false,
+      "hasNextPage": false
+    }
+  }
+  

--- a/cypress/fixtures/issues-page-filter-unresolved.json
+++ b/cypress/fixtures/issues-page-filter-unresolved.json
@@ -1,0 +1,46 @@
+{
+    "items": [
+      {
+        "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "TypeError",
+        "message": "setting getter-only property R",
+        "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "warning",
+        "status": "open",
+        "numEvents": 26,
+        "numUsers": 24
+      },
+      {
+        "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "ReferenceError",
+        "message": "C is not defined",
+        "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "warning",
+        "status": "open",
+        "numEvents": 12,
+        "numUsers": 11
+      },
+      {
+        "id": "91a43bad-14f3-4cc0-b48f-d5b9cef31443",
+        "projectId": "340cb147-6397-4a12-aa77-41100acf085f",
+        "name": "TypeError",
+        "message": "Cannot read property H of undefined",
+        "stack": "Cannot read property \"x\" of undefined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "warning",
+        "status": "open",
+        "numEvents": 10,
+        "numUsers": 10
+      }
+    ],
+    "meta": {
+      "currentPage": 1,
+      "limit": 10,
+      "totalItems": 3,
+      "totalPages": 1,
+      "hasPreviousPage": false,
+      "hasNextPage": false
+    }
+  }
+  

--- a/cypress/fixtures/issues-page-filter-unresolved.json
+++ b/cypress/fixtures/issues-page-filter-unresolved.json
@@ -1,46 +1,45 @@
 {
-    "items": [
-      {
-        "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "TypeError",
-        "message": "setting getter-only property R",
-        "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "warning",
-        "status": "open",
-        "numEvents": 26,
-        "numUsers": 24
-      },
-      {
-        "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "ReferenceError",
-        "message": "C is not defined",
-        "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "warning",
-        "status": "open",
-        "numEvents": 12,
-        "numUsers": 11
-      },
-      {
-        "id": "91a43bad-14f3-4cc0-b48f-d5b9cef31443",
-        "projectId": "340cb147-6397-4a12-aa77-41100acf085f",
-        "name": "TypeError",
-        "message": "Cannot read property H of undefined",
-        "stack": "Cannot read property \"x\" of undefined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "warning",
-        "status": "open",
-        "numEvents": 10,
-        "numUsers": 10
-      }
-    ],
-    "meta": {
-      "currentPage": 1,
-      "limit": 10,
-      "totalItems": 3,
-      "totalPages": 1,
-      "hasPreviousPage": false,
-      "hasNextPage": false
+  "items": [
+    {
+      "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "TypeError",
+      "message": "setting getter-only property R",
+      "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "warning",
+      "status": "open",
+      "numEvents": 26,
+      "numUsers": 24
+    },
+    {
+      "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "ReferenceError",
+      "message": "C is not defined",
+      "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "warning",
+      "status": "open",
+      "numEvents": 12,
+      "numUsers": 11
+    },
+    {
+      "id": "91a43bad-14f3-4cc0-b48f-d5b9cef31443",
+      "projectId": "340cb147-6397-4a12-aa77-41100acf085f",
+      "name": "TypeError",
+      "message": "Cannot read property H of undefined",
+      "stack": "Cannot read property \"x\" of undefined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "warning",
+      "status": "open",
+      "numEvents": 10,
+      "numUsers": 10
     }
+  ],
+  "meta": {
+    "currentPage": 1,
+    "limit": 10,
+    "totalItems": 3,
+    "totalPages": 1,
+    "hasPreviousPage": false,
+    "hasNextPage": false
   }
-  
+}

--- a/cypress/fixtures/issues-page-filter-warning.json
+++ b/cypress/fixtures/issues-page-filter-warning.json
@@ -1,56 +1,56 @@
 {
-    "items": [
-      {
-        "id": "1f62d084-cc32-4c7b-943d-417c5dac896e",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "TypeError",
-        "message": "U is not a function",
-        "stack": "\"x\" is not a function\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "warning",
-        "status": "resolved",
-        "numEvents": 45,
-        "numUsers": 34
-      },
-      {
-        "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "TypeError",
-        "message": "setting getter-only property R",
-        "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "warning",
-        "status": "open",
-        "numEvents": 26,
-        "numUsers": 24
-      },
-      {
-        "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
-        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
-        "name": "ReferenceError",
-        "message": "C is not defined",
-        "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "warning",
-        "status": "open",
-        "numEvents": 12,
-        "numUsers": 11
-      },
-      {
-        "id": "91a43bad-14f3-4cc0-b48f-d5b9cef31443",
-        "projectId": "340cb147-6397-4a12-aa77-41100acf085f",
-        "name": "TypeError",
-        "message": "Cannot read property H of undefined",
-        "stack": "Cannot read property \"x\" of undefined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
-        "level": "warning",
-        "status": "open",
-        "numEvents": 10,
-        "numUsers": 10
-      }
-    ],
-    "meta": {
-      "currentPage": 1,
-      "limit": 10,
-      "totalItems": 4,
-      "totalPages": 1,
-      "hasPreviousPage": false,
-      "hasNextPage": false
+  "items": [
+    {
+      "id": "1f62d084-cc32-4c7b-943d-417c5dac896e",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "TypeError",
+      "message": "U is not a function",
+      "stack": "\"x\" is not a function\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "warning",
+      "status": "resolved",
+      "numEvents": 45,
+      "numUsers": 34
+    },
+    {
+      "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "TypeError",
+      "message": "setting getter-only property R",
+      "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "warning",
+      "status": "open",
+      "numEvents": 26,
+      "numUsers": 24
+    },
+    {
+      "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
+      "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+      "name": "ReferenceError",
+      "message": "C is not defined",
+      "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "warning",
+      "status": "open",
+      "numEvents": 12,
+      "numUsers": 11
+    },
+    {
+      "id": "91a43bad-14f3-4cc0-b48f-d5b9cef31443",
+      "projectId": "340cb147-6397-4a12-aa77-41100acf085f",
+      "name": "TypeError",
+      "message": "Cannot read property H of undefined",
+      "stack": "Cannot read property \"x\" of undefined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+      "level": "warning",
+      "status": "open",
+      "numEvents": 10,
+      "numUsers": 10
     }
+  ],
+  "meta": {
+    "currentPage": 1,
+    "limit": 10,
+    "totalItems": 4,
+    "totalPages": 1,
+    "hasPreviousPage": false,
+    "hasNextPage": false
   }
+}

--- a/cypress/fixtures/issues-page-filter-warning.json
+++ b/cypress/fixtures/issues-page-filter-warning.json
@@ -1,0 +1,56 @@
+{
+    "items": [
+      {
+        "id": "1f62d084-cc32-4c7b-943d-417c5dac896e",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "TypeError",
+        "message": "U is not a function",
+        "stack": "\"x\" is not a function\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "warning",
+        "status": "resolved",
+        "numEvents": 45,
+        "numUsers": 34
+      },
+      {
+        "id": "ead13b50-3662-4150-99a3-0b1e4e8e4b5b",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "TypeError",
+        "message": "setting getter-only property R",
+        "stack": "setting getter-only property \"x\"\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "warning",
+        "status": "open",
+        "numEvents": 26,
+        "numUsers": 24
+      },
+      {
+        "id": "a0ffc9a5-7105-4640-92b2-5c360db976bf",
+        "projectId": "6d5fff43-d691-445d-a41a-7d0c639080e6",
+        "name": "ReferenceError",
+        "message": "C is not defined",
+        "stack": "\"x\" is not defined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "warning",
+        "status": "open",
+        "numEvents": 12,
+        "numUsers": 11
+      },
+      {
+        "id": "91a43bad-14f3-4cc0-b48f-d5b9cef31443",
+        "projectId": "340cb147-6397-4a12-aa77-41100acf085f",
+        "name": "TypeError",
+        "message": "Cannot read property H of undefined",
+        "stack": "Cannot read property \"x\" of undefined\n    at eval (webpack-internal:///./pages/index.tsx:37:7)\n    at invokePassiveEffectCreate (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23482:20)\n    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3945:14)\n    at HTMLUnknownElement.sentryWrapped (webpack-internal:///./node_modules/@sentry/browser/esm/helpers.js:81:23)\n    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3994:16)\n    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4056:31)\n    at flushPassiveEffectsImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23569:9)\n    at unstable_runWithPriority (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:468:12)\n    at runWithPriority$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11276:10)\n    at flushPassiveEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23442:14)\n    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23319:11)\n    at workLoop (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:417:34)\n    at flushWork (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:390:14)\n    at MessagePort.performWorkUntilDeadline (webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:157:27)",
+        "level": "warning",
+        "status": "open",
+        "numEvents": 10,
+        "numUsers": 10
+      }
+    ],
+    "meta": {
+      "currentPage": 1,
+      "limit": 10,
+      "totalItems": 4,
+      "totalPages": 1,
+      "hasPreviousPage": false,
+      "hasNextPage": false
+    }
+  }

--- a/features/issues/api/use-get-issues.tsx
+++ b/features/issues/api/use-get-issues.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getIssues } from "@api/issues";
 import type { Page } from "@typings/page.types";
 import { Issue, IssueStatus } from "@api/issues.types";
+import { useRouter } from "next/router";
 
 const QUERY_KEY = "issues";
 
@@ -23,9 +24,23 @@ export function getQueryKey(page?: number) {
 }
 
 export function useGetIssues(page: number) {
+  const router = useRouter();
+  let { status } = router.query;
+
+  //checking status select box
+  if (typeof status === "string") {
+    status = ["unresolved", "resolved"].includes(status) ? status : undefined;
+  } else {
+    status = undefined;
+  }
+
   const query = useQuery<Page<Issue>, Error>(
-    getQueryKey(page),
-    ({ signal }) => getIssues(page, { signal }),
+    [getQueryKey(page), status],
+    ({ signal }) =>
+      getIssues(page, { signal, status } as {
+        signal: AbortSignal;
+        status?: "unresolved" | "resolved";
+      }),
     {
       keepPreviousData: true,
       select: (data) => {

--- a/features/issues/api/use-get-issues.tsx
+++ b/features/issues/api/use-get-issues.tsx
@@ -2,51 +2,62 @@ import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getIssues } from "@api/issues";
 import type { Page } from "@typings/page.types";
-import { Issue, IssueStatus } from "@api/issues.types";
+import { Issue, IssueLevel, IssueStatus } from "@api/issues.types";
 
 const QUERY_KEY = "issues";
 
-type Status = "unresolved" | "resolved";
-type Level = "info" | "warning" | "error";
+export function getQueryKey(
+  page?: number,
+  status?: string,
+  level?: string,
+  project?: string,
+) {
+  return [QUERY_KEY, page, status, level, project];
+}
 
-function transformIssueStatus(status: string | undefined): IssueStatus {
-  if (status === undefined) {
-    // handle the undefined case, perhaps return a default value or throw an error
-    return IssueStatus.unresolved; // or throw new Error('status is undefined');
+// Function to transform IssueStatus to API status
+function toApiIssueStatus(status: IssueStatus | undefined): string | undefined {
+  switch (status) {
+    case IssueStatus.unresolved:
+      return "open";
+    case IssueStatus.resolved:
+      return "resolved";
+    default:
+      return undefined;
   }
+}
 
+// Function to transform API status to IssueStatus
+function fromApiIssueStatus(
+  status: string | undefined,
+): IssueStatus | undefined {
   switch (status) {
     case "open":
       return IssueStatus.unresolved;
+    case "resolved":
+      return IssueStatus.resolved;
     default:
-      return status as IssueStatus;
+      return undefined;
   }
 }
 
-export function getQueryKey(page?: number, status?: string, level?: string) {
-  return [QUERY_KEY, page, status, level];
-}
-
-export function useGetIssues(page: number, status?: string, level?: string) {
-  // Convert status to a valid value or undefined
-  const validStatus = ["open", "resolved"].includes(status ?? "")
-    ? status
-    : "open";
-  const validLevel = level ?? "";
-
-  // Explicitly cast variables to expected types
-  const statusAsStatus = transformIssueStatus(validStatus) as Status;
-  const levelAsLevel = validLevel as Level;
-
+// Use the new functions in useGetIssues
+export function useGetIssues(
+  page: number,
+  status?: IssueStatus,
+  level?: IssueLevel,
+  project?: string,
+) {
+  const apiStatus = toApiIssueStatus(status);
   const query = useQuery<Page<Issue>, Error>(
-    getQueryKey(page, validStatus, validLevel),
-    ({ signal }) => getIssues(page, validStatus, levelAsLevel, { signal }),
+    getQueryKey(page, status, level, project),
+    ({ signal }) => getIssues(page, apiStatus, level, project, { signal }),
     {
       keepPreviousData: true,
       select: (data) => {
         data.items = data.items.map((issue) => ({
           ...issue,
-          status: transformIssueStatus(issue.status),
+          status: fromApiIssueStatus(issue.status),
         }));
         return data;
       },
@@ -58,20 +69,14 @@ export function useGetIssues(page: number, status?: string, level?: string) {
   useEffect(() => {
     if (query.data?.meta.hasNextPage) {
       queryClient.prefetchQuery(
-        getQueryKey(page + 1, validStatus, level),
+        getQueryKey(page + 1, status, level, project),
         ({ signal }) =>
-          getIssues(page + 1, validStatus, levelAsLevel, { signal }),
+          getIssues(page + 1, toApiIssueStatus(status), level, project, {
+            signal,
+          }),
       );
     }
-  }, [
-    query.data,
-    page,
-    validStatus,
-    level,
-    queryClient,
-    levelAsLevel,
-    statusAsStatus,
-  ]);
+  }, [query.data, page, level, queryClient, status, project]);
 
   return query;
 }

--- a/features/issues/api/use-get-issues.tsx
+++ b/features/issues/api/use-get-issues.tsx
@@ -3,11 +3,18 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getIssues } from "@api/issues";
 import type { Page } from "@typings/page.types";
 import { Issue, IssueStatus } from "@api/issues.types";
-import { useRouter } from "next/router";
 
 const QUERY_KEY = "issues";
 
-function transformIssueStatus(status: string): IssueStatus {
+type Status = "unresolved" | "resolved";
+type Level = "info" | "warning" | "error";
+
+function transformIssueStatus(status: string | undefined): IssueStatus {
+  if (status === undefined) {
+    // handle the undefined case, perhaps return a default value or throw an error
+    return IssueStatus.unresolved; // or throw new Error('status is undefined');
+  }
+
   switch (status) {
     case "open":
       return IssueStatus.unresolved;
@@ -16,31 +23,24 @@ function transformIssueStatus(status: string): IssueStatus {
   }
 }
 
-export function getQueryKey(page?: number) {
-  if (page === undefined) {
-    return [QUERY_KEY];
-  }
-  return [QUERY_KEY, page];
+export function getQueryKey(page?: number, status?: string, level?: string) {
+  return [QUERY_KEY, page, status, level];
 }
 
-export function useGetIssues(page: number) {
-  const router = useRouter();
-  let { status } = router.query;
+export function useGetIssues(page: number, status?: string, level?: string) {
+  // Convert status to a valid value or undefined
+  const validStatus = ["open", "resolved"].includes(status ?? "")
+    ? status
+    : "open";
+  const validLevel = level ?? "";
 
-  //checking status select box
-  if (typeof status === "string") {
-    status = ["unresolved", "resolved"].includes(status) ? status : undefined;
-  } else {
-    status = undefined;
-  }
+  // Explicitly cast variables to expected types
+  const statusAsStatus = transformIssueStatus(validStatus) as Status;
+  const levelAsLevel = validLevel as Level;
 
   const query = useQuery<Page<Issue>, Error>(
-    [getQueryKey(page), status],
-    ({ signal }) =>
-      getIssues(page, { signal, status } as {
-        signal: AbortSignal;
-        status?: "unresolved" | "resolved";
-      }),
+    getQueryKey(page, validStatus, validLevel),
+    ({ signal }) => getIssues(page, validStatus, levelAsLevel, { signal }),
     {
       keepPreviousData: true,
       select: (data) => {
@@ -57,10 +57,21 @@ export function useGetIssues(page: number) {
   const queryClient = useQueryClient();
   useEffect(() => {
     if (query.data?.meta.hasNextPage) {
-      queryClient.prefetchQuery(getQueryKey(page + 1), ({ signal }) =>
-        getIssues(page + 1, { signal }),
+      queryClient.prefetchQuery(
+        getQueryKey(page + 1, validStatus, level),
+        ({ signal }) =>
+          getIssues(page + 1, validStatus, levelAsLevel, { signal }),
       );
     }
-  }, [query.data, page, queryClient]);
+  }, [
+    query.data,
+    page,
+    validStatus,
+    level,
+    queryClient,
+    levelAsLevel,
+    statusAsStatus,
+  ]);
+
   return query;
 }

--- a/features/issues/api/use-get-issues.tsx
+++ b/features/issues/api/use-get-issues.tsx
@@ -36,6 +36,8 @@ function fromApiIssueStatus(
       return IssueStatus.unresolved;
     case "resolved":
       return IssueStatus.resolved;
+    case IssueStatus.unresolved:
+      return status;
     default:
       return undefined;
   }

--- a/features/issues/components/issue-filter/index.ts
+++ b/features/issues/components/issue-filter/index.ts
@@ -1,0 +1,1 @@
+export { IssueFilter } from "./issue-filter";

--- a/features/issues/components/issue-filter/index.ts
+++ b/features/issues/components/issue-filter/index.ts
@@ -1,1 +1,2 @@
 export { IssueFilter } from "./issue-filter";
+export { IssueNoResults } from "./issue-no-results";

--- a/features/issues/components/issue-filter/issue-filter.module.scss
+++ b/features/issues/components/issue-filter/issue-filter.module.scss
@@ -13,7 +13,6 @@
 
 .selectFilter {
   width: 10rem;
-  gap: 3.5rem;
 }
 
 .inputFilter {

--- a/features/issues/components/issue-filter/issue-filter.module.scss
+++ b/features/issues/components/issue-filter/issue-filter.module.scss
@@ -11,3 +11,7 @@
   width: 10rem;
   gap: 3.5rem;
 }
+
+.inputFilter {
+  width: 14rem;
+}

--- a/features/issues/components/issue-filter/issue-filter.module.scss
+++ b/features/issues/components/issue-filter/issue-filter.module.scss
@@ -1,0 +1,7 @@
+.filterContainer {
+  display: flex;
+  height: 1px;
+  align-items: flex-start;
+  gap: 16px;
+  flex: 1 0 0;
+}

--- a/features/issues/components/issue-filter/issue-filter.module.scss
+++ b/features/issues/components/issue-filter/issue-filter.module.scss
@@ -1,7 +1,13 @@
 .filterContainer {
   display: flex;
-  height: 1px;
+  height: auto;
   align-items: flex-start;
+  justify-content: center;
   gap: 16px;
   flex: 1 0 0;
+}
+
+.selectFilter {
+  width: 10rem;
+  gap: 3.5rem;
 }

--- a/features/issues/components/issue-filter/issue-filter.module.scss
+++ b/features/issues/components/issue-filter/issue-filter.module.scss
@@ -1,10 +1,14 @@
 .filterContainer {
   display: flex;
   height: auto;
-  align-items: flex-start;
-  justify-content: center;
-  gap: 16px;
-  flex: 1 0 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.rightGroup {
+  display: flex;
+  gap: 1rem;
 }
 
 .selectFilter {

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -118,9 +118,7 @@ export function IssueFilter() {
         value={search}
         placeholder="Project Name"
         disabled={false}
-        label=""
-        hint=""
-        error=""
+        classNames={{ input: styles.inputFilter }}
         icon=<InputIcon src="/icons/search.svg" />
       />
     </div>

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -99,6 +99,7 @@ export function IssueFilter() {
         Resolve selected issues
       </Button>
       <SelectBox
+        classNames={{ button: styles.selectFilter }}
         ref={statusRef}
         options={issueStatus}
         onChange={handleStatusChange}
@@ -106,6 +107,7 @@ export function IssueFilter() {
       />
 
       <SelectBox
+        classNames={{ button: styles.selectFilter }}
         ref={levelRef}
         options={issueLevels}
         onChange={handleLevelChange}

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -52,7 +52,6 @@ export function IssueFilter({ showButton = true }) {
     levelRef.current?.setValue(level as string);
   }, [status, level]);
 
-  console.log(router.isReady, router.query.project);
   useEffect(() => {
     if (router.isReady && router.query.project) {
       const projectNameFromUrl = Array.isArray(router.query.project)
@@ -91,16 +90,23 @@ export function IssueFilter({ showButton = true }) {
 
     setSearchTimeout(
       setTimeout(() => {
-        if (value !== "") {
-          router.push({
-            pathname: router.pathname,
-            query: { ...router.query, project: value },
-          });
-        }
+        // Update the URL even when the input is empty
+        router.push({
+          pathname: router.pathname,
+          query: { ...router.query, project: value },
+        });
         setDebouncedSearch(value);
       }, 500),
     );
   };
+
+  useEffect(() => {
+    return () => {
+      if (searchTimeout) {
+        clearTimeout(searchTimeout);
+      }
+    };
+  }, [searchTimeout]);
 
   useGetIssues(1, status, level, debouncedSearch);
 

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -5,11 +5,13 @@ import {
   ButtonVariant,
   ButtonIcon,
   SelectBox,
+  InputBox,
+  InputIcon,
 } from "@features/ui";
 import { IssueLevel, IssueStatus } from "@api/issues.types";
-// import type { Issue } from "@api/issues.types";
 import capitalize from "lodash/capitalize";
 import styles from "./issue-filter.module.scss";
+import { useRouter } from "next/router";
 
 export function IssueFilter() {
   const issueLevels = Object.values(IssueLevel).map((level) => ({
@@ -21,6 +23,8 @@ export function IssueFilter() {
     value: status,
     label: capitalize(status),
   }));
+
+  const router = useRouter();
 
   return (
     <div className={styles.filterContainer}>
@@ -37,10 +41,13 @@ export function IssueFilter() {
       </Button>
       <SelectBox
         options={issueStatus}
-        onChange={() => {
-          // Add your logic here
+        onChange={(option) => {
+          router.push({
+            pathname: router.pathname,
+            query: { ...router.query, status: option },
+          });
         }}
-        placeholder="Status" // Add the placeholder property
+        placeholder="Status"
       />
       <SelectBox
         options={issueLevels}
@@ -48,6 +55,17 @@ export function IssueFilter() {
           // Add your logic here
         }}
         placeholder="Level" // Add the placeholder property
+      />
+      <InputBox
+        onChange={() => {
+          // Add your logic here
+        }}
+        placeholder="Project Name"
+        disabled={false}
+        label=""
+        hint=""
+        error=""
+        icon=<InputIcon src="/icons/search.svg" />
       />
     </div>
   );

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -98,29 +98,31 @@ export function IssueFilter() {
         <ButtonIcon src="/icons/check.svg" />
         Resolve selected issues
       </Button>
-      <SelectBox
-        classNames={{ button: styles.selectFilter }}
-        ref={statusRef}
-        options={issueStatus}
-        onChange={handleStatusChange}
-        placeholder="Status"
-      />
+      <div className={styles.rightGroup}>
+        <SelectBox
+          classNames={{ button: styles.selectFilter }}
+          ref={statusRef}
+          options={issueStatus}
+          onChange={handleStatusChange}
+          placeholder="Status"
+        />
 
-      <SelectBox
-        classNames={{ button: styles.selectFilter }}
-        ref={levelRef}
-        options={issueLevels}
-        onChange={handleLevelChange}
-        placeholder="Level"
-      />
-      <InputBox
-        onChange={handleSearchChange}
-        value={search}
-        placeholder="Project Name"
-        disabled={false}
-        classNames={{ input: styles.inputFilter }}
-        icon=<InputIcon src="/icons/search.svg" />
-      />
+        <SelectBox
+          classNames={{ button: styles.selectFilter }}
+          ref={levelRef}
+          options={issueLevels}
+          onChange={handleLevelChange}
+          placeholder="Level"
+        />
+        <InputBox
+          onChange={handleSearchChange}
+          value={search}
+          placeholder="Project Name"
+          disabled={false}
+          classNames={{ input: styles.inputFilter }}
+          icon=<InputIcon src="/icons/search.svg" />
+        />
+      </div>
     </div>
   );
 }

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -107,6 +107,7 @@ export function IssueFilter({ showButton = true }) {
           options={issueStatus}
           onChange={handleStatusChange}
           placeholder="Status"
+          allowReselectPlaceholder={true}
         />
 
         <SelectBox
@@ -115,6 +116,7 @@ export function IssueFilter({ showButton = true }) {
           options={issueLevels}
           onChange={handleLevelChange}
           placeholder="Level"
+          allowReselectPlaceholder={true}
         />
         <InputBox
           onChange={handleSearchChange}

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -15,7 +15,7 @@ import { useRouter } from "next/router";
 import { useGetIssues } from "@features/issues";
 import { useRef, useEffect, useState } from "react";
 
-export function IssueFilter() {
+export function IssueFilter({ showButton = true }) {
   const issueLevels = Object.values(IssueLevel).map((level) => ({
     value: level,
     label: capitalize(level),
@@ -87,17 +87,19 @@ export function IssueFilter() {
 
   return (
     <div className={styles.filterContainer}>
-      <Button
-        size={ButtonSize.Large}
-        color={ButtonColor.Primary}
-        variant={ButtonVariant.Default}
-        onClick={() => {
-          console.log("button click");
-        }}
-      >
-        <ButtonIcon src="/icons/check.svg" />
-        Resolve selected issues
-      </Button>
+      {showButton && (
+        <Button
+          size={ButtonSize.Large}
+          color={ButtonColor.Primary}
+          variant={ButtonVariant.Default}
+          onClick={() => {
+            console.log("button click");
+          }}
+        >
+          <ButtonIcon src="/icons/check.svg" />
+          Resolve selected issues
+        </Button>
+      )}
       <div className={styles.rightGroup}>
         <SelectBox
           classNames={{ button: styles.selectFilter }}

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -6,12 +6,14 @@ import {
   ButtonIcon,
   SelectBox,
   InputBox,
-  InputIcon,
+  InputIcon, // Import useGetIssues from the root @features folder
 } from "@features/ui";
 import { IssueLevel, IssueStatus } from "@api/issues.types";
 import capitalize from "lodash/capitalize";
 import styles from "./issue-filter.module.scss";
 import { useRouter } from "next/router";
+import { useGetIssues } from "@features/issues";
+import { useRef, useEffect } from "react";
 
 export function IssueFilter() {
   const issueLevels = Object.values(IssueLevel).map((level) => ({
@@ -25,6 +27,31 @@ export function IssueFilter() {
   }));
 
   const router = useRouter();
+  const { status, level } = router.query;
+
+  useGetIssues(1, status as string, level as string);
+
+  const statusRef = useRef<{ setValue: (value: string) => void } | null>(null);
+  const levelRef = useRef<{ setValue: (value: string) => void } | null>(null);
+
+  useEffect(() => {
+    statusRef.current?.setValue(status as string);
+    levelRef.current?.setValue(level as string);
+  }, [status, level]);
+
+  const handleStatusChange = (selectedStatus: string) => {
+    router.push({
+      pathname: router.pathname,
+      query: { ...router.query, status: selectedStatus },
+    });
+  };
+
+  const handleLevelChange = (selectedLevel: string) => {
+    router.push({
+      pathname: router.pathname,
+      query: { ...router.query, level: selectedLevel },
+    });
+  };
 
   return (
     <div className={styles.filterContainer}>
@@ -40,21 +67,17 @@ export function IssueFilter() {
         Resolve selected issues
       </Button>
       <SelectBox
+        ref={statusRef}
         options={issueStatus}
-        onChange={(option) => {
-          router.push({
-            pathname: router.pathname,
-            query: { ...router.query, status: option },
-          });
-        }}
+        onChange={handleStatusChange}
         placeholder="Status"
       />
+
       <SelectBox
+        ref={levelRef}
         options={issueLevels}
-        onChange={() => {
-          // Add your logic here
-        }}
-        placeholder="Level" // Add the placeholder property
+        onChange={handleLevelChange}
+        placeholder="Level"
       />
       <InputBox
         onChange={() => {

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -6,7 +6,7 @@ import {
   ButtonIcon,
   SelectBox,
 } from "@features/ui";
-import { IssueLevel } from "@api/issues.types";
+import { IssueLevel, IssueStatus } from "@api/issues.types";
 // import type { Issue } from "@api/issues.types";
 import capitalize from "lodash/capitalize";
 import styles from "./issue-filter.module.scss";
@@ -15,6 +15,11 @@ export function IssueFilter() {
   const issueLevels = Object.values(IssueLevel).map((level) => ({
     value: level,
     label: capitalize(level),
+  }));
+
+  const issueStatus = Object.values(IssueStatus).map((status) => ({
+    value: status,
+    label: capitalize(status),
   }));
 
   return (
@@ -31,10 +36,7 @@ export function IssueFilter() {
         Resolve selected issues
       </Button>
       <SelectBox
-        options={[
-          { value: "option1", label: "Option 1" },
-          { value: "option2", label: "Option 2" },
-        ]}
+        options={issueStatus}
         onChange={() => {
           // Add your logic here
         }}

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -1,0 +1,52 @@
+import {
+  Button,
+  ButtonSize,
+  ButtonColor,
+  ButtonVariant,
+  ButtonIcon,
+  SelectBox,
+} from "@features/ui";
+import { IssueLevel } from "@api/issues.types";
+// import type { Issue } from "@api/issues.types";
+import capitalize from "lodash/capitalize";
+import styles from "./issue-filter.module.scss";
+
+export function IssueFilter() {
+  const issueLevels = Object.values(IssueLevel).map((level) => ({
+    value: level,
+    label: capitalize(level),
+  }));
+
+  return (
+    <div className={styles.filterContainer}>
+      <Button
+        size={ButtonSize.Large}
+        color={ButtonColor.Primary}
+        variant={ButtonVariant.Default}
+        onClick={() => {
+          console.log("button click");
+        }}
+      >
+        <ButtonIcon src="/icons/check.svg" />
+        Resolve selected issues
+      </Button>
+      <SelectBox
+        options={[
+          { value: "option1", label: "Option 1" },
+          { value: "option2", label: "Option 2" },
+        ]}
+        onChange={() => {
+          // Add your logic here
+        }}
+        placeholder="Status" // Add the placeholder property
+      />
+      <SelectBox
+        options={issueLevels}
+        onChange={() => {
+          // Add your logic here
+        }}
+        placeholder="Level" // Add the placeholder property
+      />
+    </div>
+  );
+}

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -127,6 +127,8 @@ export function IssueFilter({ showButton = true }) {
       )}
       <div className={styles.rightGroup}>
         <SelectBox
+          dataTestId="status-select"
+          data-test-test="tester"
           classNames={{ button: styles.selectFilter }}
           ref={statusRef}
           options={issueStatus}
@@ -136,6 +138,7 @@ export function IssueFilter({ showButton = true }) {
         />
 
         <SelectBox
+          dataTestId="level-select"
           classNames={{ button: styles.selectFilter }}
           ref={levelRef}
           options={issueLevels}
@@ -144,6 +147,7 @@ export function IssueFilter({ showButton = true }) {
           allowReselectPlaceholder={true}
         />
         <InputBox
+          data-testid="search-input"
           onChange={handleSearchChange}
           initialValue={search}
           placeholder="Project Name"

--- a/features/issues/components/issue-filter/issue-filter.tsx
+++ b/features/issues/components/issue-filter/issue-filter.tsx
@@ -147,7 +147,7 @@ export function IssueFilter({ showButton = true }) {
           allowReselectPlaceholder={true}
         />
         <InputBox
-          data-testid="search-input"
+          dataTestId="search-input"
           onChange={handleSearchChange}
           initialValue={search}
           placeholder="Project Name"

--- a/features/issues/components/issue-filter/issue-no-results.module.scss
+++ b/features/issues/components/issue-filter/issue-no-results.module.scss
@@ -7,8 +7,7 @@
   padding: 0 2rem;
   flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
-  justify-content: center;
+  gap: 5rem;
 }
 
 .contentContainer {
@@ -17,6 +16,7 @@
   align-items: center;
   width: 22rem;
   justify-content: center;
+  flex: 2;
 }
 
 .textContainer {
@@ -46,4 +46,11 @@
   gap: 0.8125rem;
   align-self: stretch;
   width: 22rem;
+}
+
+.filterContainer {
+  display: flex;
+  align-items: flex-end;
+  flex: 1;
+  margin-left: 45%;
 }

--- a/features/issues/components/issue-filter/issue-no-results.module.scss
+++ b/features/issues/components/issue-filter/issue-no-results.module.scss
@@ -1,8 +1,49 @@
+@use "@styles/color";
+@use "@styles/space";
+@use "@styles/font";
+
 .noResultContainer {
   display: flex;
   padding: 0 2rem;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: 1.5rem;
+  justify-content: center;
+}
+
+.contentContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 22rem;
+  justify-content: center;
+}
+
+.textContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
   align-self: stretch;
+}
+
+.header {
+  color: color.$gray-900;
+  text-align: center;
+  font: font.$text-md-medium;
+  height: 0;
+}
+
+.paragraph {
+  color: color.$gray-500;
+  text-align: center;
+  font: font.$text-sm-regular;
+}
+
+.button {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.8125rem;
+  align-self: stretch;
+  width: 22rem;
 }

--- a/features/issues/components/issue-filter/issue-no-results.module.scss
+++ b/features/issues/components/issue-filter/issue-no-results.module.scss
@@ -1,0 +1,8 @@
+.noResultContainer {
+  display: flex;
+  padding: 0 2rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.5rem;
+  align-self: stretch;
+}

--- a/features/issues/components/issue-filter/issue-no-results.tsx
+++ b/features/issues/components/issue-filter/issue-no-results.tsx
@@ -1,8 +1,18 @@
 import { Button, ButtonSize } from "@features/ui";
 import styles from "./issue-no-results.module.scss";
 import { IssueFilter } from "./issue-filter";
+import { useRouter } from "next/router";
 
 export function IssueNoResults() {
+  const router = useRouter();
+
+  const clearFilters = () => {
+    router.push({
+      pathname: router.pathname,
+      query: { results: "none" },
+    });
+  };
+
   return (
     <div className={styles.noResultContainer}>
       <div className={styles.filterContainer}>
@@ -21,7 +31,11 @@ export function IssueNoResults() {
           </p>
         </div>
         <div>
-          <Button size={ButtonSize.Large} className={styles.button}>
+          <Button
+            size={ButtonSize.Large}
+            className={styles.button}
+            onClick={clearFilters}
+          >
             Clear Filters
           </Button>
         </div>

--- a/features/issues/components/issue-filter/issue-no-results.tsx
+++ b/features/issues/components/issue-filter/issue-no-results.tsx
@@ -1,18 +1,25 @@
-import { Button } from "@features/ui";
+import { Button, ButtonSize } from "@features/ui";
 import styles from "./issue-no-results.module.scss";
 
 export function IssueNoResults() {
   return (
     <div className={styles.noResultContainer}>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src="/icons/illustration.svg" alt="cloud and search glass" />
-      <h2>No issues found</h2>
-      <p>
-        Either the filters you selected are too restrictive or there are no
-        issues for your projects.
-      </p>
-      <div>
-        <Button />
+      <div>Filter here</div>
+      <div className={styles.contentContainer}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src="/icons/illustration.svg" alt="cloud and search glass" />
+        <div className={styles.textContainer}>
+          <h2 className={styles.header}>No issues found</h2>
+          <p className={styles.paragraph}>
+            Either the filters you selected are too restrictive or there are no
+            issues for your projects.
+          </p>
+        </div>
+        <div>
+          <Button size={ButtonSize.Large} className={styles.button}>
+            Clear Filters
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/features/issues/components/issue-filter/issue-no-results.tsx
+++ b/features/issues/components/issue-filter/issue-no-results.tsx
@@ -1,0 +1,19 @@
+import { Button } from "@features/ui";
+import styles from "./issue-no-results.module.scss";
+
+export function IssueNoResults() {
+  return (
+    <div className={styles.noResultContainer}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src="/icons/illustration.svg" alt="cloud and search glass" />
+      <h2>No issues found</h2>
+      <p>
+        Either the filters you selected are too restrictive or there are no
+        issues for your projects.
+      </p>
+      <div>
+        <Button />
+      </div>
+    </div>
+  );
+}

--- a/features/issues/components/issue-filter/issue-no-results.tsx
+++ b/features/issues/components/issue-filter/issue-no-results.tsx
@@ -1,10 +1,15 @@
 import { Button, ButtonSize } from "@features/ui";
 import styles from "./issue-no-results.module.scss";
+import { IssueFilter } from "./issue-filter";
 
 export function IssueNoResults() {
   return (
     <div className={styles.noResultContainer}>
-      <div>Filter here</div>
+      <div className={styles.filterContainer}>
+        <div>
+          <IssueFilter showButton={false} />
+        </div>
+      </div>
       <div className={styles.contentContainer}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src="/icons/illustration.svg" alt="cloud and search glass" />

--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -2,12 +2,16 @@
 @use "@styles/space";
 @use "@styles/font";
 
+.issueListContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
 .filterListContainer {
   display: flex;
-  padding: 0 32px;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 24px;
+  gap: 1.5rem;
   align-self: stretch;
 }
 

--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -2,6 +2,15 @@
 @use "@styles/space";
 @use "@styles/font";
 
+.filterListContainer {
+  display: flex;
+  padding: 0 32px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 24px;
+  align-self: stretch;
+}
+
 .container {
   background: white;
   border: 1px solid color.$gray-200;

--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -42,6 +42,10 @@
   font: font.$text-xs-medium;
 }
 
+.checkboxCell {
+  display: flex;
+}
+
 .paginationContainer {
   display: flex;
   align-items: center;

--- a/features/issues/components/issue-list/issue-list.tsx
+++ b/features/issues/components/issue-list/issue-list.tsx
@@ -26,11 +26,6 @@ export function IssueList() {
       const allChecked = Object.values(newState).every((val) => val === true);
       const someChecked = Object.values(newState).some((val) => val === true);
 
-      // Log the new state
-      console.log("New state:", newState);
-      console.log("All checked:", allChecked);
-      console.log("Some checked:", someChecked);
-
       // Update the allChecked and someChecked state
       setAllChecked(allChecked);
       setSomeChecked(someChecked);
@@ -139,6 +134,7 @@ export function IssueList() {
                 onCheckboxChange={() =>
                   handleCheckboxChange(issue.id as unknown as number)
                 }
+                status={status}
               />
             ))}
           </tbody>

--- a/features/issues/components/issue-list/issue-list.tsx
+++ b/features/issues/components/issue-list/issue-list.tsx
@@ -6,6 +6,7 @@ import { IssueRow } from "./issue-row";
 import styles from "./issue-list.module.scss";
 import { IssueFilter } from "../issue-filter";
 import { IssueLevel, IssueStatus } from "@api/issues.types";
+import { Checkbox, CheckboxSize } from "@features/ui";
 
 export function IssueList() {
   const router = useRouter();
@@ -55,7 +56,10 @@ export function IssueList() {
         <table className={styles.table}>
           <thead>
             <tr className={styles.headerRow}>
-              <th className={styles.headerCell}>Issue</th>
+              <th className={`${styles.headerCell} ${styles.checkboxCell}`}>
+                <Checkbox size={CheckboxSize.Small} />
+                Issue
+              </th>
               <th className={styles.headerCell}>Level</th>
               <th className={styles.headerCell}>Events</th>
               <th className={styles.headerCell}>Users</th>

--- a/features/issues/components/issue-list/issue-list.tsx
+++ b/features/issues/components/issue-list/issue-list.tsx
@@ -4,6 +4,7 @@ import { useGetProjects } from "@features/projects";
 import { useGetIssues } from "../../api/use-get-issues";
 import { IssueRow } from "./issue-row";
 import styles from "./issue-list.module.scss";
+import { IssueFilter } from "../issue-filter";
 
 export function IssueList() {
   const router = useRouter();
@@ -41,46 +42,51 @@ export function IssueList() {
   const { items, meta } = issuesPage.data || {};
 
   return (
-    <div className={styles.container}>
-      <table className={styles.table}>
-        <thead>
-          <tr className={styles.headerRow}>
-            <th className={styles.headerCell}>Issue</th>
-            <th className={styles.headerCell}>Level</th>
-            <th className={styles.headerCell}>Events</th>
-            <th className={styles.headerCell}>Users</th>
-          </tr>
-        </thead>
-        <tbody>
-          {(items || []).map((issue) => (
-            <IssueRow
-              key={issue.id}
-              issue={issue}
-              projectLanguage={projectIdToLanguage[issue.projectId]}
-            />
-          ))}
-        </tbody>
-      </table>
-      <div className={styles.paginationContainer}>
-        <div>
-          <button
-            className={styles.paginationButton}
-            onClick={() => navigateToPage(page - 1)}
-            disabled={page === 1}
-          >
-            Previous
-          </button>
-          <button
-            className={styles.paginationButton}
-            onClick={() => navigateToPage(page + 1)}
-            disabled={page === meta?.totalPages}
-          >
-            Next
-          </button>
-        </div>
-        <div className={styles.pageInfo}>
-          Page <span className={styles.pageNumber}>{meta?.currentPage}</span> of{" "}
-          <span className={styles.pageNumber}>{meta?.totalPages}</span>
+    <div>
+      <div className={styles.filterListContainer}>
+        <IssueFilter />
+      </div>
+      <div className={styles.container}>
+        <table className={styles.table}>
+          <thead>
+            <tr className={styles.headerRow}>
+              <th className={styles.headerCell}>Issue</th>
+              <th className={styles.headerCell}>Level</th>
+              <th className={styles.headerCell}>Events</th>
+              <th className={styles.headerCell}>Users</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(items || []).map((issue) => (
+              <IssueRow
+                key={issue.id}
+                issue={issue}
+                projectLanguage={projectIdToLanguage[issue.projectId]}
+              />
+            ))}
+          </tbody>
+        </table>
+        <div className={styles.paginationContainer}>
+          <div>
+            <button
+              className={styles.paginationButton}
+              onClick={() => navigateToPage(page - 1)}
+              disabled={page === 1}
+            >
+              Previous
+            </button>
+            <button
+              className={styles.paginationButton}
+              onClick={() => navigateToPage(page + 1)}
+              disabled={page === meta?.totalPages}
+            >
+              Next
+            </button>
+          </div>
+          <div className={styles.pageInfo}>
+            Page <span className={styles.pageNumber}>{meta?.currentPage}</span>{" "}
+            of <span className={styles.pageNumber}>{meta?.totalPages}</span>
+          </div>
         </div>
       </div>
     </div>

--- a/features/issues/components/issue-list/issue-list.tsx
+++ b/features/issues/components/issue-list/issue-list.tsx
@@ -9,13 +9,16 @@ import { IssueFilter } from "../issue-filter";
 export function IssueList() {
   const router = useRouter();
   const page = Number(router.query.page || 1);
+  const status = router.query.status as string;
+  const level = router.query.level as string;
+
   const navigateToPage = (newPage: number) =>
     router.push({
       pathname: router.pathname,
       query: { page: newPage },
     });
 
-  const issuesPage = useGetIssues(page);
+  const issuesPage = useGetIssues(page, status, level);
   const projects = useGetProjects();
 
   if (projects.isLoading || issuesPage.isLoading) {

--- a/features/issues/components/issue-list/issue-list.tsx
+++ b/features/issues/components/issue-list/issue-list.tsx
@@ -112,12 +112,14 @@ export function IssueList() {
           <thead>
             <tr className={styles.headerRow}>
               <th className={`${styles.headerCell} ${styles.checkboxCell}`}>
-                <Checkbox
-                  size={CheckboxSize.Small}
-                  checked={allChecked}
-                  indeterminate={!allChecked && someChecked}
-                  onChange={handleAllCheckboxChange}
-                />
+                {status === IssueStatus.unresolved && (
+                  <Checkbox
+                    size={CheckboxSize.Small}
+                    checked={allChecked}
+                    indeterminate={!allChecked && someChecked}
+                    onChange={handleAllCheckboxChange}
+                  />
+                )}
                 Issue
               </th>
               <th className={styles.headerCell}>Level</th>

--- a/features/issues/components/issue-list/issue-list.tsx
+++ b/features/issues/components/issue-list/issue-list.tsx
@@ -47,7 +47,7 @@ export function IssueList() {
   const { items, meta } = issuesPage.data || {};
 
   return (
-    <div>
+    <div className={styles.issueListContainer}>
       <div className={styles.filterListContainer}>
         <IssueFilter />
       </div>

--- a/features/issues/components/issue-list/issue-list.tsx
+++ b/features/issues/components/issue-list/issue-list.tsx
@@ -4,7 +4,7 @@ import { useGetProjects } from "@features/projects";
 import { useGetIssues } from "../../api/use-get-issues";
 import { IssueRow } from "./issue-row";
 import styles from "./issue-list.module.scss";
-import { IssueFilter } from "../issue-filter";
+import { IssueFilter, IssueNoResults } from "../issue-filter";
 import { IssueLevel, IssueStatus } from "@api/issues.types";
 import { Checkbox, CheckboxSize } from "@features/ui";
 import { useState } from "react";
@@ -23,8 +23,13 @@ export function IssueList() {
   const handleCheckboxChange = (id: number) => {
     setCheckedIssues((prevState) => {
       const newState = { ...prevState, [id]: !prevState[id] };
-      const allChecked = Object.values(newState).every((val) => val);
-      const someChecked = Object.values(newState).some((val) => val);
+      const allChecked = Object.values(newState).every((val) => val === true);
+      const someChecked = Object.values(newState).some((val) => val === true);
+
+      // Log the new state
+      console.log("New state:", newState);
+      console.log("All checked:", allChecked);
+      console.log("Some checked:", someChecked);
 
       // Update the allChecked and someChecked state
       setAllChecked(allChecked);
@@ -82,6 +87,10 @@ export function IssueList() {
   if (issuesPage.isError) {
     console.error(issuesPage.error);
     return <div>Error loading issues: {issuesPage.error.message}</div>;
+  }
+
+  if (issuesPage.data && issuesPage.data.items.length === 0) {
+    return <IssueNoResults />;
   }
 
   const projectIdToLanguage = (projects.data || []).reduce(

--- a/features/issues/components/issue-list/issue-list.tsx
+++ b/features/issues/components/issue-list/issue-list.tsx
@@ -5,20 +5,22 @@ import { useGetIssues } from "../../api/use-get-issues";
 import { IssueRow } from "./issue-row";
 import styles from "./issue-list.module.scss";
 import { IssueFilter } from "../issue-filter";
+import { IssueLevel, IssueStatus } from "@api/issues.types";
 
 export function IssueList() {
   const router = useRouter();
   const page = Number(router.query.page || 1);
-  const status = router.query.status as string;
-  const level = router.query.level as string;
+  const status = router.query.status as keyof typeof IssueStatus as IssueStatus;
+  const level = router.query.level as keyof typeof IssueLevel as IssueLevel;
+  const project = router.query.project as string;
 
   const navigateToPage = (newPage: number) =>
     router.push({
       pathname: router.pathname,
-      query: { page: newPage },
+      query: { page: newPage, project, status, level },
     });
 
-  const issuesPage = useGetIssues(page, status, level);
+  const issuesPage = useGetIssues(page, status, level, project);
   const projects = useGetProjects();
 
   if (projects.isLoading || issuesPage.isLoading) {
@@ -64,7 +66,7 @@ export function IssueList() {
               <IssueRow
                 key={issue.id}
                 issue={issue}
-                projectLanguage={projectIdToLanguage[issue.projectId]}
+                projectLanguage={projectIdToLanguage[issue.projectId] || ""}
               />
             ))}
           </tbody>

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -33,8 +33,6 @@ export function IssueRow({
   const { name, message, stack, level, numEvents, numUsers, status } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
 
-  console.log("Issue status:", status);
-
   return (
     <tr className={styles.row}>
       <td className={styles.issueCell}>

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -29,8 +29,9 @@ export function IssueRow({
   issue,
   isChecked,
   onCheckboxChange,
-}: IssueRowProps) {
-  const { name, message, stack, level, numEvents, numUsers, status } = issue;
+  status,
+}: IssueRowProps & { status: IssueStatus }) {
+  const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
 
   return (

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -14,6 +14,8 @@ import styles from "./issue-row.module.scss";
 type IssueRowProps = {
   projectLanguage: ProjectLanguage;
   issue: Issue;
+  isChecked: boolean;
+  onCheckboxChange: () => void;
 };
 
 const levelColors = {
@@ -22,14 +24,23 @@ const levelColors = {
   [IssueLevel.error]: BadgeColor.error,
 };
 
-export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
+export function IssueRow({
+  projectLanguage,
+  issue,
+  isChecked,
+  onCheckboxChange,
+}: IssueRowProps) {
   const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
 
   return (
     <tr className={styles.row}>
       <td className={styles.issueCell}>
-        <Checkbox size={CheckboxSize.Small} />
+        <Checkbox
+          size={CheckboxSize.Small}
+          checked={isChecked}
+          onChange={onCheckboxChange}
+        />
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           className={styles.languageIcon}

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -7,7 +7,7 @@ import {
   CheckboxSize,
 } from "@features/ui";
 import { ProjectLanguage } from "@api/projects.types";
-import { IssueLevel } from "@api/issues.types";
+import { IssueLevel, IssueStatus } from "@api/issues.types";
 import type { Issue } from "@api/issues.types";
 import styles from "./issue-row.module.scss";
 
@@ -30,17 +30,21 @@ export function IssueRow({
   isChecked,
   onCheckboxChange,
 }: IssueRowProps) {
-  const { name, message, stack, level, numEvents, numUsers } = issue;
+  const { name, message, stack, level, numEvents, numUsers, status } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
+
+  console.log("Issue status:", status);
 
   return (
     <tr className={styles.row}>
       <td className={styles.issueCell}>
-        <Checkbox
-          size={CheckboxSize.Small}
-          checked={isChecked}
-          onChange={onCheckboxChange}
-        />
+        {status === IssueStatus.unresolved && (
+          <Checkbox
+            size={CheckboxSize.Small}
+            checked={isChecked}
+            onChange={onCheckboxChange}
+          />
+        )}
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           className={styles.languageIcon}

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -1,5 +1,11 @@
 import capitalize from "lodash/capitalize";
-import { Badge, BadgeColor, BadgeSize } from "@features/ui";
+import {
+  Badge,
+  BadgeColor,
+  BadgeSize,
+  Checkbox,
+  CheckboxSize,
+} from "@features/ui";
 import { ProjectLanguage } from "@api/projects.types";
 import { IssueLevel } from "@api/issues.types";
 import type { Issue } from "@api/issues.types";
@@ -23,6 +29,7 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
   return (
     <tr className={styles.row}>
       <td className={styles.issueCell}>
+        <Checkbox size={CheckboxSize.Small} />
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           className={styles.languageIcon}

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -38,7 +38,10 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
         </div>
       </td>
       <td className={styles.cell}>
-        <Badge color={levelColors[level]} size={BadgeSize.sm}>
+        <Badge
+          color={levelColors[level as keyof typeof levelColors]}
+          size={BadgeSize.sm}
+        >
           {capitalize(level)}
         </Badge>
       </td>

--- a/features/issues/index.ts
+++ b/features/issues/index.ts
@@ -1,1 +1,2 @@
 export * from "./components/issue-list";
+export * from "./api/use-get-issues";

--- a/features/ui/button/button.module.scss
+++ b/features/ui/button/button.module.scss
@@ -11,6 +11,7 @@
   border-radius: space.$s2;
   box-shadow: shadow.$xs;
   font: font.$text-md-medium;
+  min-width: 0;
 }
 
 .icon {
@@ -41,10 +42,11 @@
 }
 
 .large {
-  height: 2.75rem;
+  min-height: 2.75rem;
   padding: 0.625rem 1.125rem;
   font: font.$text-md-medium;
   letter-spacing: 0.0313rem;
+  flex-shrink: 1;
 
   &.iconOnly {
     padding: 0.625rem;

--- a/features/ui/checkbox/checkbox.tsx
+++ b/features/ui/checkbox/checkbox.tsx
@@ -64,7 +64,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           {/* span is is the custom shown checkbox*/}
           <svg
             className={styles.indeterminateCheck}
-            data-testId="indeterminate-check"
+            data-testid="indeterminate-check"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 12 12"
             fill="none"
@@ -79,7 +79,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           </svg>
           <svg
             className={styles.check}
-            data-testId="check"
+            data-testid="check"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 12 12"
             fill="none"

--- a/features/ui/checkbox/checkboxCheckbox.cy.tsx
+++ b/features/ui/checkbox/checkboxCheckbox.cy.tsx
@@ -30,7 +30,7 @@ describe("<Checkbox />", () => {
 
         rerender(<Checkbox checked={true} onChange={() => {}} />);
         cy.get("input[type='checkbox']").should("be.checked");
-        cy.get("svg[data-testId=check]").should("be.visible");
+        cy.get("svg[data-testid=check]").should("be.visible");
       },
     );
   });
@@ -39,11 +39,11 @@ describe("<Checkbox />", () => {
     cy.mount(<Checkbox indeterminate={true} onChange={() => {}} />).then(
       ({ rerender }) => {
         cy.get("input[type='checkbox']:indeterminate").should("exist");
-        cy.get("svg[data-testId=indeterminate-check]").should("be.visible");
+        cy.get("svg[data-testid=indeterminate-check]").should("be.visible");
 
         rerender(<Checkbox indeterminate={false} onChange={() => {}} />);
         cy.get("input[type='checkbox']:indeterminate").should("not.exist");
-        cy.get("svg[data-testId=indeterminate-check]").should("not.be.visible");
+        cy.get("svg[data-testid=indeterminate-check]").should("not.be.visible");
       },
     );
   });

--- a/features/ui/index.ts
+++ b/features/ui/index.ts
@@ -2,3 +2,5 @@ export * from "./badge";
 export * from "./button";
 export * from "./loading";
 export * from "./checkbox";
+export * from "./select";
+export * from "./input";

--- a/features/ui/input/input.tsx
+++ b/features/ui/input/input.tsx
@@ -3,6 +3,7 @@ import React, {
   forwardRef,
   useImperativeHandle,
   useState,
+  useEffect,
 } from "react";
 import styles from "./input.module.scss";
 
@@ -14,7 +15,7 @@ type InputBoxProps = {
   icon?: ReactElement;
   hint?: string;
   error?: string;
-  value?: string;
+  initialValue?: string;
   classNames?: {
     container?: string;
     label?: string;
@@ -38,11 +39,16 @@ export const InputBox = forwardRef<
       icon,
       hint,
       error,
+      initialValue,
       classNames = {},
     },
     ref,
   ) => {
-    const [value, setValue] = useState("");
+    const [value, setValue] = useState(initialValue);
+
+    useEffect(() => {
+      setValue(initialValue);
+    }, [initialValue]);
 
     const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       setValue(event.target.value);

--- a/features/ui/input/input.tsx
+++ b/features/ui/input/input.tsx
@@ -8,85 +8,114 @@ import styles from "./input.module.scss";
 
 type InputBoxProps = {
   onChange: (value: string) => void;
-  placeholder: string;
-  disabled: boolean;
-  label: string;
+  placeholder?: string;
+  disabled?: boolean;
+  label?: string;
   icon?: ReactElement;
-  hint: string;
-  error: string;
-  value: string;
+  hint?: string;
+  error?: string;
+  value?: string;
+  classNames?: {
+    container?: string;
+    label?: string;
+    wrapper?: string;
+    input?: string;
+    hint?: string;
+    error?: string;
+  };
 };
 
 export const InputBox = forwardRef<
   { setValue: (value: string) => void },
   InputBoxProps
->(({ onChange, placeholder, disabled, label, icon, hint, error }, ref) => {
-  const [value, setValue] = useState("");
-
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(event.target.value);
-    onChange(event.target.value);
-  };
-
-  // This allows the parent component to control the value of the input box
-  useImperativeHandle(ref, () => ({
-    setValue: (value: string) => {
-      setValue(value);
+>(
+  (
+    {
+      onChange,
+      placeholder,
+      disabled,
+      label,
+      icon,
+      hint,
+      error,
+      classNames = {},
     },
-  }));
-  return (
-    <div className={styles.inputBoxContainer}>
-      <div className={styles.label}>{label}</div>
-      <div className={styles.inputWrapper}>
-        {icon && <div className={styles.inputIcon}>{icon}</div>}
-        <input
-          placeholder={placeholder}
-          className={`${styles.inputBox} ${icon ? styles.inputBoxWithIcon : ""} ${error ? styles.errorContainer : ""}`}
-          onChange={handleInputChange}
-          value={value}
-          disabled={disabled}
-        />
-        {error && (
-          <div className={styles.errorIcon} data-testid="input-error">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 16 17"
-              fill="none"
-            >
-              <g clipPath="url(#clip0_47_612)">
-                <path
-                  d="M8.00016 5.45966V8.12632M8.00016 10.793H8.00683M14.6668 8.12632C14.6668 11.8082 11.6821 14.793 8.00016 14.793C4.31826 14.793 1.3335 11.8082 1.3335 8.12632C1.3335 4.44442 4.31826 1.45966 8.00016 1.45966C11.6821 1.45966 14.6668 4.44442 14.6668 8.12632Z"
-                  stroke="#F04438"
-                  strokeWidth="1.33333"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </g>
-              <defs>
-                <clipPath id="clip0_47_612">
-                  <rect
-                    width="16"
-                    height="16"
-                    fill="white"
-                    transform="translate(0 0.126343)"
+    ref,
+  ) => {
+    const [value, setValue] = useState("");
+
+    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setValue(event.target.value);
+      onChange(event.target.value);
+    };
+
+    // This allows the parent component to control the value of the input box
+    useImperativeHandle(ref, () => ({
+      setValue: (value: string) => {
+        setValue(value);
+      },
+    }));
+    return (
+      <div
+        className={`${styles.inputBoxContainer} ${classNames.container || ""}`}
+      >
+        <div className={`${styles.label} ${classNames.label || ""}`}>
+          {label}
+        </div>
+        <div className={`${styles.inputWrapper} ${classNames.wrapper || ""}`}>
+          {icon && <div className={styles.inputIcon}>{icon}</div>}
+          <input
+            placeholder={placeholder}
+            className={`${styles.inputBox} ${icon ? styles.inputBoxWithIcon : ""} ${error ? styles.errorContainer : ""} ${classNames.input}`}
+            onChange={handleInputChange}
+            value={value}
+            disabled={disabled}
+          />
+          {error && (
+            <div className={styles.errorIcon} data-testid="input-error">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 16 17"
+                fill="none"
+              >
+                <g clipPath="url(#clip0_47_612)">
+                  <path
+                    d="M8.00016 5.45966V8.12632M8.00016 10.793H8.00683M14.6668 8.12632C14.6668 11.8082 11.6821 14.793 8.00016 14.793C4.31826 14.793 1.3335 11.8082 1.3335 8.12632C1.3335 4.44442 4.31826 1.45966 8.00016 1.45966C11.6821 1.45966 14.6668 4.44442 14.6668 8.12632Z"
+                    stroke="#F04438"
+                    strokeWidth="1.33333"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                   />
-                </clipPath>
-              </defs>
-            </svg>
+                </g>
+                <defs>
+                  <clipPath id="clip0_47_612">
+                    <rect
+                      width="16"
+                      height="16"
+                      fill="white"
+                      transform="translate(0 0.126343)"
+                    />
+                  </clipPath>
+                </defs>
+              </svg>
+            </div>
+          )}
+        </div>
+        {error ? (
+          <div data-testid="input-error" className={styles.error}>
+            {error}
+          </div>
+        ) : (
+          <div
+            data-testid="input-hint"
+            className={`${styles.hint} ${classNames.hint || ""}`}
+          >
+            {hint}
           </div>
         )}
       </div>
-      {error ? (
-        <div data-testid="input-error" className={styles.error}>
-          {error}
-        </div>
-      ) : (
-        <div data-testid="input-hint" className={styles.hint}>
-          {hint}
-        </div>
-      )}
-    </div>
-  );
-});
+    );
+  },
+);
 
 InputBox.displayName = "InputBox";

--- a/features/ui/input/input.tsx
+++ b/features/ui/input/input.tsx
@@ -14,6 +14,7 @@ type InputBoxProps = {
   icon?: ReactElement;
   hint: string;
   error: string;
+  value: string;
 };
 
 export const InputBox = forwardRef<

--- a/features/ui/input/input.tsx
+++ b/features/ui/input/input.tsx
@@ -24,6 +24,7 @@ type InputBoxProps = {
     hint?: string;
     error?: string;
   };
+  dataTestId?: string;
 };
 
 export const InputBox = forwardRef<
@@ -41,6 +42,7 @@ export const InputBox = forwardRef<
       error,
       initialValue,
       classNames = {},
+      dataTestId,
     },
     ref,
   ) => {
@@ -71,6 +73,7 @@ export const InputBox = forwardRef<
         <div className={`${styles.inputWrapper} ${classNames.wrapper || ""}`}>
           {icon && <div className={styles.inputIcon}>{icon}</div>}
           <input
+            data-testid={dataTestId}
             placeholder={placeholder}
             className={`${styles.inputBox} ${icon ? styles.inputBoxWithIcon : ""} ${error ? styles.errorContainer : ""} ${classNames.input}`}
             onChange={handleInputChange}

--- a/features/ui/input/inputInputBox.cy.tsx
+++ b/features/ui/input/inputInputBox.cy.tsx
@@ -10,8 +10,11 @@ describe("<InputBox />", () => {
   const hint = "Hint text";
 
   it("Input box placeholder and typing is working", () => {
+    const value = "value";
+
     cy.mount(
       <InputBox
+        value={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}
@@ -32,8 +35,10 @@ describe("<InputBox />", () => {
   });
 
   it("Input focus is working", () => {
+    const value = "value";
     cy.mount(
       <InputBox
+        value={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}
@@ -62,8 +67,10 @@ describe("<InputBox />", () => {
   });
 
   it("Input icon and error icon is working", () => {
+    const value = "value";
     cy.mount(
       <InputBox
+        value={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}
@@ -78,6 +85,7 @@ describe("<InputBox />", () => {
 
     cy.mount(
       <InputBox
+        value={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}
@@ -95,9 +103,11 @@ describe("<InputBox />", () => {
   });
 
   it("Hint and error messages are working", () => {
+    const value = "value";
     //With an error
     cy.mount(
       <InputBox
+        value={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}
@@ -114,6 +124,7 @@ describe("<InputBox />", () => {
     //Without an error
     cy.mount(
       <InputBox
+        value={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}

--- a/features/ui/input/inputInputBox.cy.tsx
+++ b/features/ui/input/inputInputBox.cy.tsx
@@ -14,7 +14,7 @@ describe("<InputBox />", () => {
 
     cy.mount(
       <InputBox
-        value={value}
+        initialValue={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}
@@ -38,7 +38,7 @@ describe("<InputBox />", () => {
     const value = "value";
     cy.mount(
       <InputBox
-        value={value}
+        initialValue={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}
@@ -70,7 +70,7 @@ describe("<InputBox />", () => {
     const value = "value";
     cy.mount(
       <InputBox
-        value={value}
+        initialValue={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}
@@ -85,7 +85,7 @@ describe("<InputBox />", () => {
 
     cy.mount(
       <InputBox
-        value={value}
+        initialValue={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}
@@ -107,7 +107,7 @@ describe("<InputBox />", () => {
     //With an error
     cy.mount(
       <InputBox
-        value={value}
+        initialValue={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}
@@ -124,7 +124,7 @@ describe("<InputBox />", () => {
     //Without an error
     cy.mount(
       <InputBox
-        value={value}
+        initialValue={value}
         onChange={() => {}}
         placeholder={placeholderText}
         label={label}

--- a/features/ui/select/select.module.scss
+++ b/features/ui/select/select.module.scss
@@ -118,3 +118,7 @@
   color: color.$error-500;
   font: font.$text-sm-regular;
 }
+
+.placeholderOption {
+  color: color.$gray-500;
+}

--- a/features/ui/select/select.tsx
+++ b/features/ui/select/select.tsx
@@ -20,6 +20,12 @@ type SelectBoxProps = {
   label?: string;
   hint?: string;
   errorText?: string;
+  classNames?: {
+    container?: string;
+    label?: string;
+    button?: string;
+    hint?: string;
+  };
 };
 
 export const SelectBox = forwardRef<
@@ -27,7 +33,17 @@ export const SelectBox = forwardRef<
   SelectBoxProps
 >(
   (
-    { options, onChange, placeholder, disabled, icon, label, hint, errorText },
+    {
+      options,
+      onChange,
+      placeholder,
+      disabled,
+      icon,
+      label,
+      hint,
+      errorText,
+      classNames = {},
+    },
     ref,
   ) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -47,11 +63,15 @@ export const SelectBox = forwardRef<
     }));
 
     return (
-      <div className={styles.selectBoxContainer}>
-        <div className={styles.label}>{label}</div>
+      <div
+        className={`${styles.selectBoxContainer} ${classNames.container || ""}`}
+      >
+        <div className={`${styles.label} ${classNames.label || ""}`}>
+          {label}
+        </div>
         <button
           data-testid="select-box"
-          className={`${styles.selectContainer} ${selectedOption ? "" : styles.placeholder} ${errorText ? styles.errorContainer : ""}`}
+          className={`${styles.selectContainer} ${selectedOption ? "" : styles.placeholder} ${errorText ? styles.errorContainer : ""} ${classNames.button || ""}`}
           onClick={() => setIsOpen(!isOpen)}
           disabled={disabled && !errorText}
         >
@@ -129,7 +149,10 @@ export const SelectBox = forwardRef<
             {errorText}
           </div>
         ) : (
-          <div data-testid="select-hint" className={styles.hint}>
+          <div
+            data-testid="select-hint"
+            className={`${styles.hint} ${classNames.hint || ""}`}
+          >
             {hint}
           </div>
         )}

--- a/features/ui/select/select.tsx
+++ b/features/ui/select/select.tsx
@@ -27,144 +27,141 @@ type SelectBoxProps = {
     hint?: string;
   };
   allowReselectPlaceholder?: boolean;
+  dataTestId?: string;
 };
 
 export const SelectBox = forwardRef<
   { setValue: (value: string) => void },
   SelectBoxProps
->(
-  (
-    {
-      options,
-      onChange,
-      placeholder,
-      disabled,
-      icon,
-      label,
-      hint,
-      errorText,
-      classNames = {},
-      allowReselectPlaceholder = false,
+>((props, ref) => {
+  const {
+    options,
+    onChange,
+    placeholder,
+    disabled,
+    icon,
+    label,
+    hint,
+    errorText,
+    classNames = {},
+    allowReselectPlaceholder = false,
+    dataTestId,
+  } = props;
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedOption, setSelectedOption] = useState<Option | null>(null);
+
+  const handleOptionClick = (option: Option) => {
+    setSelectedOption(option);
+    onChange(option.value);
+  };
+
+  // This allows the parent component to control the value of the select box
+  useImperativeHandle(ref, () => ({
+    setValue: (value: string) => {
+      const option = options.find((option) => option.value === value);
+      setSelectedOption(option || null);
     },
-    ref,
-  ) => {
-    const [isOpen, setIsOpen] = useState(false);
-    const [selectedOption, setSelectedOption] = useState<Option | null>(null);
+  }));
 
-    const handleOptionClick = (option: Option) => {
-      setSelectedOption(option);
-      onChange(option.value);
-    };
+  const allOptions = allowReselectPlaceholder
+    ? [{ value: "", label: placeholder }, ...options]
+    : options;
 
-    // This allows the parent component to control the value of the select box
-    useImperativeHandle(ref, () => ({
-      setValue: (value: string) => {
-        const option = options.find((option) => option.value === value);
-        setSelectedOption(option || null);
-      },
-    }));
+  return (
+    <div
+      className={`${styles.selectBoxContainer} ${classNames.container || ""}`}
+    >
+      <div className={`${styles.label} ${classNames.label || ""}`}>{label}</div>
 
-    const allOptions = allowReselectPlaceholder
-      ? [{ value: "", label: placeholder }, ...options]
-      : options;
-
-    return (
-      <div
-        className={`${styles.selectBoxContainer} ${classNames.container || ""}`}
+      <button
+        data-testid={dataTestId || "select-box"}
+        className={`${styles.selectContainer} ${selectedOption ? "" : styles.placeholder} ${errorText ? styles.errorContainer : ""} ${classNames.button || ""}`}
+        onClick={() => setIsOpen(!isOpen)}
+        disabled={disabled && !errorText}
       >
-        <div className={`${styles.label} ${classNames.label || ""}`}>
-          {label}
+        <div className={styles.selectedBase} data-testid="select-base">
+          {icon}
+          {selectedOption ? selectedOption.label : placeholder}
         </div>
-        <button
-          data-testid="select-box"
-          className={`${styles.selectContainer} ${selectedOption ? "" : styles.placeholder} ${errorText ? styles.errorContainer : ""} ${classNames.button || ""}`}
-          onClick={() => setIsOpen(!isOpen)}
-          disabled={disabled && !errorText}
-        >
-          <div className={styles.selectedBase} data-testid="select-base">
-            {icon}
-            {selectedOption ? selectedOption.label : placeholder}
-          </div>
-          {isOpen && (
-            <div className={styles.options} data-testid="select-options">
-              {allOptions.map((option, index) => (
-                <div
-                  data-testid={`select-option-${index}`}
-                  key={option.value}
-                  className={`${styles.option} ${selectedOption === option ? styles.selected : ""} ${option.value === "" ? styles.placeholderOption : ""}`}
-                  onClick={() => handleOptionClick(option)}
-                >
-                  {option.label}
-                  {selectedOption === option && (
-                    <svg
-                      data-testid="select-check"
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 20 20"
-                      fill="none"
-                      className={styles.checkIcon}
-                    >
-                      <path
-                        d="M16.6668 5L7.50016 14.1667L3.3335 10"
-                        stroke="#7F56D9"
-                        strokeWidth="1.66667"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      />
-                    </svg>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-          {isOpen ? (
-            <svg //Open arrow
-              data-testid="select-open-arrow"
-              className={styles.openIcon}
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="none"
-            >
-              <path
-                d="M15 12.5L10 7.5L5 12.5"
-                stroke="#667085"
-                strokeWidth="1.66667"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          ) : (
-            <svg //Closed arrow
-              data-testid="select-closed-arrow"
-              className={styles.arrowIcon}
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="none"
-            >
-              <path
-                d="M5 7.5L10 12.5L15 7.5"
-                stroke="#667085"
-                strokeWidth="1.66667"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          )}
-        </button>
-        {errorText ? (
-          <div data-testid="select-error" className={styles.errorText}>
-            {errorText}
-          </div>
-        ) : (
-          <div
-            data-testid="select-hint"
-            className={`${styles.hint} ${classNames.hint || ""}`}
-          >
-            {hint}
+        {isOpen && (
+          <div className={styles.options} data-testid="select-options">
+            {allOptions.map((option, index) => (
+              <div
+                data-testid={`select-option-${index}`}
+                key={option.value}
+                className={`${styles.option} ${selectedOption === option ? styles.selected : ""} ${option.value === "" ? styles.placeholderOption : ""}`}
+                onClick={() => handleOptionClick(option)}
+              >
+                {option.label}
+                {selectedOption === option && (
+                  <svg
+                    data-testid="select-check"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    className={styles.checkIcon}
+                  >
+                    <path
+                      d="M16.6668 5L7.50016 14.1667L3.3335 10"
+                      stroke="#7F56D9"
+                      strokeWidth="1.66667"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                )}
+              </div>
+            ))}
           </div>
         )}
-      </div>
-    );
-  },
-);
+        {isOpen ? (
+          <svg //Open arrow
+            data-testid="select-open-arrow"
+            className={styles.openIcon}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="none"
+          >
+            <path
+              d="M15 12.5L10 7.5L5 12.5"
+              stroke="#667085"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ) : (
+          <svg //Closed arrow
+            data-testid="select-closed-arrow"
+            className={styles.arrowIcon}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="none"
+          >
+            <path
+              d="M5 7.5L10 12.5L15 7.5"
+              stroke="#667085"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        )}
+      </button>
+      {errorText ? (
+        <div data-testid="select-error" className={styles.errorText}>
+          {errorText}
+        </div>
+      ) : (
+        <div
+          data-testid="select-hint"
+          className={`${styles.hint} ${classNames.hint || ""}`}
+        >
+          {hint}
+        </div>
+      )}
+    </div>
+  );
+});
 
 SelectBox.displayName = "SelectBox";

--- a/features/ui/select/select.tsx
+++ b/features/ui/select/select.tsx
@@ -26,6 +26,7 @@ type SelectBoxProps = {
     button?: string;
     hint?: string;
   };
+  allowReselectPlaceholder?: boolean;
 };
 
 export const SelectBox = forwardRef<
@@ -43,6 +44,7 @@ export const SelectBox = forwardRef<
       hint,
       errorText,
       classNames = {},
+      allowReselectPlaceholder = false,
     },
     ref,
   ) => {
@@ -61,6 +63,10 @@ export const SelectBox = forwardRef<
         setSelectedOption(option || null);
       },
     }));
+
+    const allOptions = allowReselectPlaceholder
+      ? [{ value: "", label: placeholder }, ...options]
+      : options;
 
     return (
       <div
@@ -81,11 +87,11 @@ export const SelectBox = forwardRef<
           </div>
           {isOpen && (
             <div className={styles.options} data-testid="select-options">
-              {options.map((option, index) => (
+              {allOptions.map((option, index) => (
                 <div
                   data-testid={`select-option-${index}`}
                   key={option.value}
-                  className={`${styles.option} ${selectedOption === option ? styles.selected : ""}`}
+                  className={`${styles.option} ${selectedOption === option ? styles.selected : ""} ${option.value === "" ? styles.placeholderOption : ""}`}
                   onClick={() => handleOptionClick(option)}
                 >
                   {option.label}

--- a/public/icons/Illustration.svg
+++ b/public/icons/Illustration.svg
@@ -1,0 +1,53 @@
+<svg width="152" height="120" viewBox="0 0 152 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="76" cy="52" r="52" fill="#E9D7FE"/>
+<g filter="url(#filter0_dd_99_661)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M77.6 16C66.8273 16 57.2978 21.3233 51.4987 29.4829C49.605 29.0363 47.6301 28.8 45.6 28.8C31.4615 28.8 20 40.2615 20 54.4C20 68.5385 31.4615 80 45.6 80L45.62 80H109.6C121.971 80 132 69.9712 132 57.6C132 45.2288 121.971 35.2 109.6 35.2C108.721 35.2 107.854 35.2506 107.002 35.349C102.098 23.9677 90.7797 16 77.6 16Z" fill="#F9F5FF"/>
+<ellipse cx="45.6" cy="54.4" rx="25.6" ry="25.6" fill="url(#paint0_linear_99_661)"/>
+<circle cx="77.6" cy="48" r="32" fill="url(#paint1_linear_99_661)"/>
+<ellipse cx="109.6" cy="57.5999" rx="22.4" ry="22.4" fill="url(#paint2_linear_99_661)"/>
+</g>
+<circle cx="21" cy="19" r="5" fill="#F4EBFF"/>
+<circle cx="18" cy="109" r="7" fill="#F4EBFF"/>
+<circle cx="145" cy="35" r="7" fill="#F4EBFF"/>
+<circle cx="134" cy="8" r="4" fill="#F4EBFF"/>
+<g filter="url(#filter1_b_99_661)">
+<rect x="52" y="62" width="48" height="48" rx="24" fill="#6941C6" fill-opacity="0.4"/>
+<path d="M85 95L80.65 90.65M83 85C83 89.4183 79.4183 93 75 93C70.5817 93 67 89.4183 67 85C67 80.5817 70.5817 77 75 77C79.4183 77 83 80.5817 83 85Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<filter id="filter0_dd_99_661" x="0" y="16" width="152" height="104" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect1_dropShadow_99_661"/>
+<feOffset dy="8"/>
+<feGaussianBlur stdDeviation="4"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0627451 0 0 0 0 0.0941176 0 0 0 0 0.156863 0 0 0 0.04 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_99_661"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect2_dropShadow_99_661"/>
+<feOffset dy="20"/>
+<feGaussianBlur stdDeviation="12"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0627451 0 0 0 0 0.0941176 0 0 0 0 0.156863 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_99_661" result="effect2_dropShadow_99_661"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_99_661" result="shape"/>
+</filter>
+<filter id="filter1_b_99_661" x="44" y="54" width="64" height="64" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feGaussianBlur in="BackgroundImageFix" stdDeviation="4"/>
+<feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur_99_661"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur_99_661" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_99_661" x1="25.9429" y1="37.4858" x2="71.2" y2="80" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E9D7FE"/>
+<stop offset="0.350715" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_99_661" x1="53.0286" y1="26.8571" x2="109.6" y2="80" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E9D7FE"/>
+<stop offset="0.350715" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_99_661" x1="92.4" y1="42.8" x2="132" y2="79.9999" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E9D7FE"/>
+<stop offset="0.350715" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/public/icons/check.svg
+++ b/public/icons/check.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="check">
+<path id="Icon" d="M16.6667 5L7.50001 14.1667L3.33334 10" stroke="white" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/public/icons/search.svg
+++ b/public/icons/search.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="search">
+<path id="Icon" d="M17.5 17.5L13.875 13.875M15.8333 9.16667C15.8333 12.8486 12.8486 15.8333 9.16667 15.8333C5.48477 15.8333 2.5 12.8486 2.5 9.16667C2.5 5.48477 5.48477 2.5 9.16667 2.5C12.8486 2.5 15.8333 5.48477 15.8333 9.16667Z" stroke="#667085" stroke-width="1.66667" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>


### PR DESCRIPTION
### User Story
As a user I want to filter the issue list so that I can easily narrow down the list while searching for issues matching certain criteria.

### Design
![image](https://github.com/profydev/prolog-app-jaclynmariefrench/assets/77642588/43102f66-819b-43e1-b514-4664359588b0)
[Design on Figma](https://www.figma.com/file/8ZmbMRC8PtvXx7L5PjVcVM/Prolog?node-id=0%3A1)

### Testing Criteria

- [ ] Allows filtering for “Unresolved” and “Resolved” issues
- [ ] Allows filtering for level “Error”, “Warning”, and “Info”
- [ ] Allows filtering for any existing project by (partial) project name
- [ ] Every dropdown can be empty (no value selected) to remove a filter
- [ ] Issues are displayed according to the filters
- [ ] Each filter should persist after the page is refreshed
- [ ] The user should be able to share the page including the currently selected filters


